### PR TITLE
[CHK-1359,CHK-1360] fix refund error event written multiple times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>0.9.1</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>0.9.3</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**
 		</sonar.coverage.exclusions>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumer.kt
@@ -60,7 +60,12 @@ class TransactionExpirationQueueConsumer(
     val baseTransaction = reduceEvents(transactionId, transactionsEventStoreRepository)
     val refundPipeline =
       baseTransaction
-        .filter { transactionUtils.isTransientStatus(it.status) }
+        .filter {
+          val isTransient = transactionUtils.isTransientStatus(it.status)
+          logger.info(
+            "Transaction ${it.transactionId.value} in status ${it.status}, is transient: $isTransient")
+          isTransient
+        }
         .flatMap { tx ->
           val refundable = isTransactionRefundable(tx)
           val wasAuthorizationRequested = wasAuthorizationRequested(tx)

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
@@ -23,7 +23,7 @@ fun getMockedClosePaymentRequest(
       "requestId",
       "pspBusinessName",
       "authorizationRequestId",
-    )
+      TransactionAuthorizationRequestData.PaymentGateway.VPOS)
 
   return ClosePaymentRequestV2Dto().apply {
     paymentTokens = listOf(UUID.randomUUID().toString())


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Fix bug CHK-1359: REFUND_REQUESTED and REFUND_ERROR were wrongly marked as transient statuses and then transaction in those statuses got wrongly processed by expiration queue that mark those as EXPIRED and then process refund again --> resolved upgrading commons version
2. Fix bug CHK-1360: refund pipeline write REFUND_ERROR event every time a refund error happen, also if this was triggered by a retry event
3. Add junit tests to cover above bug fixes

<!--- Describe your changes in detail -->

#### Motivation and Context

1. This fix resolve refund for a transaction to be processed twice
2. This fix resolve the fact that refund error event is written every time an error happens during refund retry: now refund error event is written only once at the first error 

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.