### PR TITLE
fix: ClosePayment additionalInformations.timestampOperation format

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
@@ -13,6 +13,8 @@ import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsEventStoreRe
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto
 import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.*
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
@@ -93,7 +95,12 @@ class NodeService(
                     "tipoVersamento" to "CP",
                     "rrn" to "123456789",
                     "fee" to ev.data.fee.toBigDecimal().toString(),
-                    "timestampOperation" to timestamp.toString(), // 2023-04-03T15:42:22.826Z
+                    // bug CHK-1410: date formatted to yyyy-MM-ddTHH:mm:ss truncating millis
+                    "timestampOperation" to
+                      timestamp
+                        .toLocalDateTime()
+                        .truncatedTo(ChronoUnit.SECONDS)
+                        .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                     "totalAmount" to (ev.data.amount.plus(ev.data.fee)).toBigDecimal().toString())
               }
             }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
@@ -255,7 +255,8 @@ class NodeServiceTests {
     val closePaymentRequestV2Dto = closePaymentRequestCaptor.value
     val expectedTimestamp =
       closePaymentRequestV2Dto.timestampOperation!!
-        .truncatedTo(ChronoUnit.SECONDS)!!
+        .toLocalDateTime()
+        .truncatedTo(ChronoUnit.SECONDS)
         .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
     assertEquals(
       expectedTimestamp,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Fix ClosePaymentRequest additionalInformations.timestampOperation date format to be formatted in `yyyy-MM-ddThh:mm:ss` format
#### Motivation and Context
Those modifications are needed to format `timestampOperation` closePayment field correctly
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.