### PR TITLE
fix: transaction id as UUID string without dashes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>0.10.1</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>0.11.0</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**
 		</sonar.coverage.exclusions>
@@ -459,8 +459,8 @@
 				<configuration>
 					<skipCheckoutIfExists>false</skipCheckoutIfExists>
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-					<scmVersionType>branch</scmVersionType>
-					<scmVersion>CHK-1413-transaction-id-max-length-35</scmVersion>
+					<scmVersionType>tag</scmVersionType>
+					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>0.9.3</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>0.10.1</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**
 		</sonar.coverage.exclusions>
@@ -459,8 +459,8 @@
 				<configuration>
 					<skipCheckoutIfExists>false</skipCheckoutIfExists>
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-					<scmVersionType>tag</scmVersionType>
-					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+					<scmVersion>CHK-1413-transaction-id-max-length-35</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/BadTransactionStatusException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/BadTransactionStatusException.kt
@@ -9,4 +9,4 @@ class BadTransactionStatusException(
   val actual: TransactionStatusDto
 ) :
   RuntimeException(
-    "Transaction with id ${transactionId.value} was expected in status $expected but is in status $actual")
+    "Transaction with id ${transactionId.value()} was expected in status $expected but is in status $actual")

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/NoRetryAttemptsLeftException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/NoRetryAttemptsLeftException.kt
@@ -8,4 +8,4 @@ class NoRetryAttemptsLeftException(
   val eventCode: TransactionEventCode
 ) :
   RuntimeException(
-    "No attempts left for retry event $eventCode for transaction id: ${transactionId.value}")
+    "No attempts left for retry event $eventCode for transaction id: ${transactionId.value()}")

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/TransactionEventNotFoundException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/TransactionEventNotFoundException.kt
@@ -1,9 +1,9 @@
 package it.pagopa.ecommerce.eventdispatcher.exceptions
 
 import it.pagopa.ecommerce.commons.domain.v1.TransactionEventCode
-import java.util.*
+import it.pagopa.ecommerce.commons.domain.v1.TransactionId
 
 class TransactionEventNotFoundException(
-  transactionId: UUID,
+  transactionId: TransactionId,
   transactionEventCode: TransactionEventCode
 ) : RuntimeException("Event $transactionEventCode not found for transaction $transactionId")

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/TransactionEventsInconsistentException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/TransactionEventsInconsistentException.kt
@@ -1,10 +1,10 @@
 package it.pagopa.ecommerce.eventdispatcher.exceptions
 
 import it.pagopa.ecommerce.commons.domain.v1.TransactionEventCode
-import java.util.*
+import it.pagopa.ecommerce.commons.domain.v1.TransactionId
 
 class TransactionEventsInconsistentException(
-  transactionId: UUID,
+  transactionId: TransactionId,
   transactionEventCode: List<TransactionEventCode>
 ) :
   RuntimeException(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/TransactionEventsPreconditionsNotMatchedException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/TransactionEventsPreconditionsNotMatchedException.kt
@@ -1,10 +1,10 @@
 package it.pagopa.ecommerce.eventdispatcher.exceptions
 
 import it.pagopa.ecommerce.commons.domain.v1.TransactionEventCode
-import java.util.*
+import it.pagopa.ecommerce.commons.domain.v1.TransactionId
 
 class TransactionEventsPreconditionsNotMatchedException(
-  transactionId: UUID,
+  transactionId: TransactionId,
   transactionEventCode: List<TransactionEventCode>
 ) :
   RuntimeException(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumer.kt
@@ -63,7 +63,7 @@ class TransactionExpirationQueueConsumer(
         .filter {
           val isTransient = transactionUtils.isTransientStatus(it.status)
           logger.info(
-            "Transaction ${it.transactionId.value} in status ${it.status}, is transient: $isTransient")
+            "Transaction ${it.transactionId.value()} in status ${it.status}, is transient: $isTransient")
           isTransient
         }
         .flatMap { tx ->
@@ -71,7 +71,7 @@ class TransactionExpirationQueueConsumer(
           val wasAuthorizationRequested = wasAuthorizationRequested(tx)
           val isTransactionExpired = isTransactionExpired(tx)
           logger.info(
-            "Transaction ${tx.transactionId.value} in status ${tx.status}, refundable: $refundable, expired: $isTransactionExpired")
+            "Transaction ${tx.transactionId.value()} in status ${tx.status}, refundable: $refundable, expired: $isTransactionExpired")
           if (!isTransactionExpired) {
             updateTransactionToExpired(
               tx,

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionNotificationsQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionNotificationsQueueConsumer.kt
@@ -67,7 +67,7 @@ class TransactionNotificationsQueueConsumer(
     val notificationResendPipeline =
       baseTransaction
         .flatMap {
-          logger.info("Status for transaction ${it.transactionId.value}: ${it.status}")
+          logger.info("Status for transaction ${it.transactionId.value()}: ${it.status}")
 
           if (it.status != TransactionStatusDto.NOTIFICATION_REQUESTED) {
             Mono.error(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionNotificationsRetryQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionNotificationsRetryQueueConsumer.kt
@@ -78,7 +78,7 @@ class TransactionNotificationsRetryQueueConsumer(
     val notificationResendPipeline =
       baseTransaction
         .flatMap {
-          logger.info("Status for transaction ${it.transactionId.value}: ${it.status}")
+          logger.info("Status for transaction ${it.transactionId.value()}: ${it.status}")
 
           if (it.status != TransactionStatusDto.NOTIFICATION_ERROR) {
             Mono.error(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionRefundRetryQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionRefundRetryQueueConsumer.kt
@@ -58,7 +58,7 @@ class TransactionRefundRetryQueueConsumer(
     val refundPipeline =
       baseTransaction
         .flatMap {
-          logger.info("Status for transaction ${it.transactionId.value}: ${it.status}")
+          logger.info("Status for transaction ${it.transactionId.value()}: ${it.status}")
 
           if (it.status != TransactionStatusDto.REFUND_ERROR) {
             Mono.error(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionsRefundQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionsRefundQueueConsumer.kt
@@ -74,7 +74,7 @@ class TransactionsRefundQueueConsumer(
             .flatMap { Mono.empty() }
         }
         .doOnNext {
-          logger.info("Handling refund request for transaction with id ${it.transactionId.value}")
+          logger.info("Handling refund request for transaction with id ${it.transactionId.value()}")
         }
         .cast(BaseTransactionWithRefundRequested::class.java)
         .flatMap { tx ->

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/ClosureRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/ClosureRetryService.kt
@@ -31,7 +31,7 @@ class ClosureRetryService(
     transactionId: TransactionId,
     transactionRetriedData: TransactionRetriedData
   ): TransactionClosureRetriedEvent =
-    TransactionClosureRetriedEvent(transactionId.value.toString(), transactionRetriedData)
+    TransactionClosureRetriedEvent(transactionId.value(), transactionRetriedData)
 
   override fun newTransactionStatus(): TransactionStatusDto = TransactionStatusDto.CLOSURE_ERROR
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/NotificationRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/NotificationRetryService.kt
@@ -31,7 +31,7 @@ class NotificationRetryService(
     transactionId: TransactionId,
     transactionRetriedData: TransactionRetriedData
   ): TransactionUserReceiptAddRetriedEvent =
-    TransactionUserReceiptAddRetriedEvent(transactionId.value.toString(), transactionRetriedData)
+    TransactionUserReceiptAddRetriedEvent(transactionId.value(), transactionRetriedData)
 
   override fun newTransactionStatus(): TransactionStatusDto =
     TransactionStatusDto.NOTIFICATION_ERROR

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/RefundRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/RefundRetryService.kt
@@ -31,7 +31,7 @@ class RefundRetryService(
     transactionId: TransactionId,
     transactionRetriedData: TransactionRetriedData
   ): TransactionRefundRetriedEvent =
-    TransactionRefundRetriedEvent(transactionId.value.toString(), transactionRetriedData)
+    TransactionRefundRetriedEvent(transactionId.value(), transactionRetriedData)
 
   override fun newTransactionStatus(): TransactionStatusDto = TransactionStatusDto.REFUND_ERROR
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionRefundRetryQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionRefundRetryQueueConsumerTest.kt
@@ -12,6 +12,7 @@ import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsEventStoreRe
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsViewRepository
 import it.pagopa.ecommerce.eventdispatcher.services.eventretry.RefundRetryService
 import it.pagopa.generated.ecommerce.gateway.v1.dto.PostePayRefundResponseDto
+import java.time.ZonedDateTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -102,6 +103,11 @@ class TransactionRefundRetryQueueConsumerTest {
     given(paymentGatewayClient.requestRefund(any())).willReturn(Mono.just(gatewayClientResponse))
     given(refundRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture()))
       .willReturn(Mono.empty())
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willReturn(
+        Mono.just(
+          TransactionTestUtils.transactionDocument(
+            TransactionStatusDto.REFUND_ERROR, ZonedDateTime.now())))
     /* test */
     StepVerifier.create(
         transactionRefundRetryQueueConsumer.messageReceiver(
@@ -171,6 +177,11 @@ class TransactionRefundRetryQueueConsumerTest {
       given(paymentGatewayClient.requestRefund(any())).willReturn(Mono.just(gatewayClientResponse))
       given(refundRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture()))
         .willReturn(Mono.empty())
+      given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+        .willReturn(
+          Mono.just(
+            TransactionTestUtils.transactionDocument(
+              TransactionStatusDto.REFUND_ERROR, ZonedDateTime.now())))
       /* test */
       StepVerifier.create(
           transactionRefundRetryQueueConsumer.messageReceiver(

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionsRefundEventsConsumerTests.kt
@@ -4,17 +4,19 @@ import com.azure.core.util.BinaryData
 import com.azure.spring.messaging.checkpoint.Checkpointer
 import it.pagopa.ecommerce.commons.documents.v1.*
 import it.pagopa.ecommerce.commons.domain.v1.TransactionEventCode
+import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionWithRequestedAuthorization
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
-import it.pagopa.ecommerce.commons.v1.TransactionTestUtils
-import it.pagopa.ecommerce.commons.v1.TransactionTestUtils.transactionAuthorizationRequestedEvent
-import it.pagopa.ecommerce.commons.v1.TransactionTestUtils.transactionClosedEvent
+import it.pagopa.ecommerce.commons.v1.*
+import it.pagopa.ecommerce.commons.v1.TransactionTestUtils.*
 import it.pagopa.ecommerce.eventdispatcher.client.PaymentGatewayClient
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsEventStoreRepository
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsViewRepository
 import it.pagopa.ecommerce.eventdispatcher.services.eventretry.RefundRetryService
 import it.pagopa.generated.ecommerce.gateway.v1.dto.PostePayRefundResponseDto
+import java.time.ZonedDateTime
 import java.util.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.reactor.mono
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -59,17 +61,16 @@ class TransactionsRefundEventsConsumerTests {
 
   @Test
   fun `consumer processes refund request event correctly with pgs refund`() = runTest {
-    val activationEvent = TransactionTestUtils.transactionActivateEvent() as TransactionEvent<Any>
+    val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
     val authorizationRequestEvent =
       transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
     val authorizationCompleteEvent =
-      TransactionTestUtils.transactionAuthorizationCompletedEvent() as TransactionEvent<Any>
+      transactionAuthorizationCompletedEvent() as TransactionEvent<Any>
     val closedEvent =
       transactionClosedEvent(TransactionClosureData.Outcome.KO) as TransactionEvent<Any>
     val refundRequestedEvent =
       TransactionRefundRequestedEvent(
-        TransactionTestUtils.TRANSACTION_ID,
-        TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
+        TRANSACTION_ID, TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
         as TransactionEvent<Any>
 
     val gatewayClientResponse = PostePayRefundResponseDto().apply { refundOutcome = "OK" }
@@ -82,56 +83,51 @@ class TransactionsRefundEventsConsumerTests {
         closedEvent,
         refundRequestedEvent)
 
-    val expectedRefundedEvent =
-      TransactionRefundedEvent(
-        TransactionTestUtils.TRANSACTION_ID,
-        TransactionRefundedData(TransactionStatusDto.AUTHORIZATION_COMPLETED))
+    val transaction =
+      reduceEvents(*events.toTypedArray()) as BaseTransactionWithRequestedAuthorization
 
     /* preconditions */
     given(checkpointer.success()).willReturn(Mono.empty())
-    given(transactionsEventStoreRepository.findByTransactionId(any())).willReturn(events.toFlux())
+    given(transactionsEventStoreRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(events.toFlux())
     given(transactionsViewRepository.save(any())).willAnswer { Mono.just(it.arguments[0]) }
     given(transactionsRefundedEventStoreRepository.save(refundEventStoreCaptor.capture()))
       .willAnswer { Mono.just(it.arguments[0]) }
     given(paymentGatewayClient.requestRefund(any())).willReturn(Mono.just(gatewayClientResponse))
+    given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(
+        mono { transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()) })
 
-    val refundedEventId = UUID.fromString(expectedRefundedEvent.id)
+    /* test */
+    StepVerifier.create(
+        transactionRefundedEventsConsumer.messageReceiver(
+          BinaryData.fromObject(refundRequestedEvent).toBytes(), checkpointer))
+      .expectNext()
+      .verifyComplete()
 
-    Mockito.mockStatic(UUID::class.java).use { uuid ->
-      uuid.`when`<Any>(UUID::randomUUID).thenReturn(refundedEventId)
-      uuid.`when`<Any> { UUID.fromString(any()) }.thenCallRealMethod()
-
-      /* test */
-      StepVerifier.create(
-          transactionRefundedEventsConsumer.messageReceiver(
-            BinaryData.fromObject(refundRequestedEvent).toBytes(), checkpointer))
-        .expectNext()
-        .verifyComplete()
-
-      /* Asserts */
-      verify(checkpointer, Mockito.times(1)).success()
-      verify(paymentGatewayClient, Mockito.times(1))
-        .requestRefund(UUID.fromString(TransactionTestUtils.TRANSACTION_ID))
-      verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-      verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any())
-      val storedEvent = refundEventStoreCaptor.value
-      assertEquals(TransactionEventCode.TRANSACTION_REFUNDED_EVENT, storedEvent.eventCode)
-      assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
-    }
+    /* Asserts */
+    verify(checkpointer, Mockito.times(1)).success()
+    verify(paymentGatewayClient, Mockito.times(1))
+      .requestRefund(
+        UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
+    verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
+    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any())
+    val storedEvent = refundEventStoreCaptor.value
+    assertEquals(TransactionEventCode.TRANSACTION_REFUNDED_EVENT, storedEvent.eventCode)
+    assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
   }
 
   @Test
   fun `consumer processes refund request event for a transaction without refund requested`() =
     runTest {
-      val activationEvent = TransactionTestUtils.transactionActivateEvent() as TransactionEvent<Any>
+      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
       val authorizationRequestEvent =
         transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
       val authorizationCompleteEvent =
-        TransactionTestUtils.transactionAuthorizationCompletedEvent() as TransactionEvent<Any>
+        transactionAuthorizationCompletedEvent() as TransactionEvent<Any>
       val refundRequestedEvent =
         TransactionRefundRequestedEvent(
-          TransactionTestUtils.TRANSACTION_ID,
-          TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
+          TRANSACTION_ID, TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
           as TransactionEvent<Any>
 
       val events =
@@ -140,10 +136,13 @@ class TransactionsRefundEventsConsumerTests {
           authorizationRequestEvent,
           authorizationCompleteEvent,
         )
+      val transaction =
+        reduceEvents(*events.toTypedArray()) as BaseTransactionWithRequestedAuthorization
 
       /* preconditions */
       given(checkpointer.success()).willReturn(Mono.empty())
-      given(transactionsEventStoreRepository.findByTransactionId(any())).willReturn(events.toFlux())
+      given(transactionsEventStoreRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturn(events.toFlux())
       given(transactionsViewRepository.save(any())).willAnswer { Mono.just(it.arguments[0]) }
 
       /* test */
@@ -157,24 +156,24 @@ class TransactionsRefundEventsConsumerTests {
       /* Asserts */
       verify(checkpointer, Mockito.times(1)).success()
       verify(paymentGatewayClient, Mockito.times(0))
-        .requestRefund(UUID.fromString(TransactionTestUtils.TRANSACTION_ID))
+        .requestRefund(
+          UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any())
     }
 
   @Test
   fun `consumer enqueue refund retry event for KO response from PGS`() = runTest {
-    val activationEvent = TransactionTestUtils.transactionActivateEvent() as TransactionEvent<Any>
+    val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
     val authorizationRequestEvent =
       transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
     val authorizationCompleteEvent =
-      TransactionTestUtils.transactionAuthorizationCompletedEvent() as TransactionEvent<Any>
+      transactionAuthorizationCompletedEvent() as TransactionEvent<Any>
     val closedEvent =
       transactionClosedEvent(TransactionClosureData.Outcome.KO) as TransactionEvent<Any>
     val refundRequestedEvent =
       TransactionRefundRequestedEvent(
-        TransactionTestUtils.TRANSACTION_ID,
-        TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
+        TRANSACTION_ID, TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
         as TransactionEvent<Any>
 
     val gatewayClientResponse = PostePayRefundResponseDto().apply { refundOutcome = "KO" }
@@ -187,43 +186,40 @@ class TransactionsRefundEventsConsumerTests {
         closedEvent,
         refundRequestedEvent)
 
-    val expectedRefundedEvent =
-      TransactionRefundedEvent(
-        TransactionTestUtils.TRANSACTION_ID,
-        TransactionRefundedData(TransactionStatusDto.AUTHORIZATION_COMPLETED))
+    val transaction =
+      reduceEvents(*events.toTypedArray()) as BaseTransactionWithRequestedAuthorization
 
     /* preconditions */
     given(checkpointer.success()).willReturn(Mono.empty())
-    given(transactionsEventStoreRepository.findByTransactionId(any())).willReturn(events.toFlux())
+    given(transactionsEventStoreRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(events.toFlux())
     given(transactionsViewRepository.save(any())).willAnswer { Mono.just(it.arguments[0]) }
     given(transactionsRefundedEventStoreRepository.save(refundEventStoreCaptor.capture()))
       .willAnswer { Mono.just(it.arguments[0]) }
     given(paymentGatewayClient.requestRefund(any())).willReturn(Mono.just(gatewayClientResponse))
     given(refundRetryService.enqueueRetryEvent(any(), any())).willReturn(Mono.empty())
-    val refundedEventId = UUID.fromString(expectedRefundedEvent.id)
+    given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(
+        Mono.just(transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now())))
 
-    Mockito.mockStatic(UUID::class.java).use { uuid ->
-      uuid.`when`<Any>(UUID::randomUUID).thenReturn(refundedEventId)
-      uuid.`when`<Any> { UUID.fromString(any()) }.thenCallRealMethod()
+    /* test */
 
-      /* test */
+    StepVerifier.create(
+        transactionRefundedEventsConsumer.messageReceiver(
+          BinaryData.fromObject(refundRequestedEvent).toBytes(), checkpointer))
+      .expectNext()
+      .verifyComplete()
 
-      StepVerifier.create(
-          transactionRefundedEventsConsumer.messageReceiver(
-            BinaryData.fromObject(refundRequestedEvent).toBytes(), checkpointer))
-        .expectNext()
-        .verifyComplete()
+    /* Asserts */
+    verify(checkpointer, Mockito.times(1)).success()
+    verify(paymentGatewayClient, Mockito.times(1))
+      .requestRefund(
+        UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
+    verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
+    verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any())
 
-      /* Asserts */
-      verify(checkpointer, Mockito.times(1)).success()
-      verify(paymentGatewayClient, Mockito.times(1))
-        .requestRefund(UUID.fromString(TransactionTestUtils.TRANSACTION_ID))
-      verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-      verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any())
-
-      val storedEvent = refundEventStoreCaptor.value
-      assertEquals(TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT, storedEvent.eventCode)
-      assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
-    }
+    val storedEvent = refundEventStoreCaptor.value
+    assertEquals(TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT, storedEvent.eventCode)
+    assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
   }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/ClosureRetryServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/ClosureRetryServiceTests.kt
@@ -75,9 +75,8 @@ class ClosureRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -90,7 +89,8 @@ class ClosureRetryServiceTests {
       .verifyComplete()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(closureRetryQueueAsyncClient, times(1))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -119,9 +119,8 @@ class ClosureRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -134,7 +133,8 @@ class ClosureRetryServiceTests {
       .verifyComplete()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(closureRetryQueueAsyncClient, times(1))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -163,9 +163,8 @@ class ClosureRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -178,7 +177,8 @@ class ClosureRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(0)).save(any())
-    verify(transactionsViewRepository, times(0)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(0))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(closureRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -200,9 +200,8 @@ class ClosureRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.error<TransactionEvent<Any>>(RuntimeException("Error saving event into event store"))
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -215,7 +214,8 @@ class ClosureRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(0)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(0))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(closureRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -235,9 +235,8 @@ class ClosureRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.error<Transaction>(RuntimeException("Error finding transaction by id"))
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.error<Transaction>(RuntimeException("Error finding transaction by id")) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -250,7 +249,8 @@ class ClosureRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(closureRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -272,9 +272,8 @@ class ClosureRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.error<Transaction>(RuntimeException("Error updating transaction view"))
     }
@@ -287,7 +286,8 @@ class ClosureRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(closureRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/NotificationRetryServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/NotificationRetryServiceTests.kt
@@ -80,9 +80,8 @@ class NotificationRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -98,7 +97,8 @@ class NotificationRetryServiceTests {
       .verifyComplete()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(notificationRetryQueueAsyncClient, times(1))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -133,9 +133,8 @@ class NotificationRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -148,7 +147,8 @@ class NotificationRetryServiceTests {
       .verifyComplete()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(notificationRetryQueueAsyncClient, times(1))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -184,9 +184,8 @@ class NotificationRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -199,7 +198,8 @@ class NotificationRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(0)).save(any())
-    verify(transactionsViewRepository, times(0)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(0))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(notificationRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -226,9 +226,8 @@ class NotificationRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.error<TransactionEvent<Any>>(RuntimeException("Error saving event into event store"))
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -242,7 +241,8 @@ class NotificationRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(0)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(0))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(notificationRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -267,9 +267,8 @@ class NotificationRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.error<Transaction>(RuntimeException("Error finding transaction by id"))
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.error<Transaction>(RuntimeException("Error finding transaction by id")) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -283,7 +282,8 @@ class NotificationRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(notificationRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -310,9 +310,8 @@ class NotificationRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.error<Transaction>(RuntimeException("Error updating transaction view"))
     }
@@ -326,7 +325,8 @@ class NotificationRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(notificationRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/RefundRetryServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/RefundRetryServiceTests.kt
@@ -80,9 +80,8 @@ class RefundRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -97,7 +96,8 @@ class RefundRetryServiceTests {
       .verifyComplete()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(refundRetryQueueAsyncClient, times(1))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -130,9 +130,8 @@ class RefundRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -145,7 +144,8 @@ class RefundRetryServiceTests {
       .verifyComplete()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(refundRetryQueueAsyncClient, times(1))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -179,9 +179,8 @@ class RefundRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -194,7 +193,8 @@ class RefundRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(0)).save(any())
-    verify(transactionsViewRepository, times(0)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(0))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(refundRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -221,9 +221,8 @@ class RefundRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.error<TransactionEvent<Any>>(RuntimeException("Error saving event into event store"))
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -236,7 +235,8 @@ class RefundRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(0)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(0))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(refundRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -261,9 +261,8 @@ class RefundRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.error<Transaction>(RuntimeException("Error finding transaction by id"))
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.error<Transaction>(RuntimeException("Error finding transaction by id")) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
@@ -276,7 +275,8 @@ class RefundRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(0)).save(any())
     verify(refundRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
@@ -303,9 +303,8 @@ class RefundRetryServiceTests {
     given(eventStoreRepository.save(eventStoreCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
-    given(transactionsViewRepository.findByTransactionId(any())).willAnswer {
-      Mono.just(transactionDocument)
-    }
+    given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
+      .willAnswer { Mono.just(transactionDocument) }
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.error<Transaction>(RuntimeException("Error updating transaction view"))
     }
@@ -318,7 +317,8 @@ class RefundRetryServiceTests {
       .verify()
 
     verify(eventStoreRepository, times(1)).save(any())
-    verify(transactionsViewRepository, times(1)).findByTransactionId(any())
+    verify(transactionsViewRepository, times(1))
+      .findByTransactionId(TransactionTestUtils.TRANSACTION_ID)
     verify(transactionsViewRepository, times(1)).save(any())
     verify(refundRetryQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/UserReceiptMailBuilderTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/UserReceiptMailBuilderTest.kt
@@ -79,7 +79,7 @@ class UserReceiptMailBuilderTest {
           TransactionTestUtils.LANGUAGE,
           SuccessTemplate(
             TransactionTemplate(
-              baseTransaction.transactionId.value.toString(),
+              baseTransaction.transactionId.value(),
               dateString,
               totalAmountWithFeeString,
               PspTemplate(TransactionTestUtils.PSP_BUSINESS_NAME, FeeTemplate(feeString)),
@@ -160,7 +160,7 @@ class UserReceiptMailBuilderTest {
           TransactionTestUtils.LANGUAGE,
           KoTemplate(
             it.pagopa.generated.notifications.templates.ko.TransactionTemplate(
-              baseTransaction.transactionId.value.toString(), dateString, amountString)))
+              baseTransaction.transactionId.value(), dateString, amountString)))
       val expected =
         NotificationEmailRequestDto()
           .language(koTemplateRequest.language)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Update commons version to 0.11.0
Refactored transactionId to handle UUID without dashes
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modification are needed to handle transaction id without dashes in order to have a transaction id lesser than 35 chars
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests, local test (ecommerce commons) and test in DEV environment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
