### PR TITLE
fix: change logo uri origin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>0.12.0</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>0.12.1</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**
 		</sonar.coverage.exclusions>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/UserReceiptMailBuilder.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/UserReceiptMailBuilder.kt
@@ -114,7 +114,7 @@ class UserReceiptMailBuilder(@Autowired private val confidentialMailUtils: Confi
             transactionAuthorizationCompletedData.authorizationCode,
             PaymentMethodTemplate(
               transactionAuthorizationRequestData.paymentMethodName,
-              transactionUserReceiptData.paymentMethodLogoUri.toString(),
+              transactionAuthorizationRequestData.logo.toString(),
               null,
               false)),
           UserTemplate(null, emailAddress),

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
@@ -1,6 +1,7 @@
 package it.pagopa.ecommerce.eventdispatcher.utils
 
 import it.pagopa.ecommerce.commons.documents.v1.TransactionAuthorizationRequestData
+import it.pagopa.ecommerce.commons.v1.TransactionTestUtils
 import it.pagopa.generated.ecommerce.gateway.v1.dto.PostePayRefundResponseDto
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto
 import java.time.OffsetDateTime
@@ -23,7 +24,8 @@ fun getMockedClosePaymentRequest(
       "requestId",
       "pspBusinessName",
       "authorizationRequestId",
-      TransactionAuthorizationRequestData.PaymentGateway.VPOS)
+      TransactionAuthorizationRequestData.PaymentGateway.VPOS,
+      TransactionTestUtils.LOGO_URI)
 
   return ClosePaymentRequestV2Dto().apply {
     paymentTokens = listOf(UUID.randomUUID().toString())

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/UserReceiptMailBuilderTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/UserReceiptMailBuilderTest.kt
@@ -87,7 +87,7 @@ class UserReceiptMailBuilderTest {
               baseTransaction.transactionAuthorizationCompletedData.authorizationCode,
               PaymentMethodTemplate(
                 TransactionTestUtils.PAYMENT_METHOD_NAME,
-                TransactionTestUtils.PAYMENT_METHOD_LOGO_URL.toString(),
+                TransactionTestUtils.LOGO_URI.toString(),
                 null,
                 false)),
             UserTemplate(null, TransactionTestUtils.EMAIL_STRING),
@@ -180,7 +180,7 @@ class UserReceiptMailBuilderTest {
               baseTransaction.transactionAuthorizationCompletedData.authorizationCode,
               PaymentMethodTemplate(
                 TransactionTestUtils.PAYMENT_METHOD_NAME,
-                TransactionTestUtils.PAYMENT_METHOD_LOGO_URL.toString(),
+                TransactionTestUtils.LOGO_URI.toString(),
                 null,
                 false)),
             UserTemplate(null, TransactionTestUtils.EMAIL_STRING),


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/204
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Change logo uri origin. Now logo uri is taken from authorization requested data instead of user receipt data
<!--- Describe your changes in detail -->

#### Motivation and Context
Change logo uri origin. Now logo uri is taken from authorization requested data instead of user receipt data
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Junit tests
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.