### PR TITLE
fix: expiration on closure error from user cancel

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumer.kt
@@ -68,16 +68,12 @@ class TransactionExpirationQueueConsumer(
         }
         .flatMap { tx ->
           val refundable = isTransactionRefundable(tx)
-          val wasAuthorizationRequested = wasAuthorizationRequested(tx)
           val isTransactionExpired = isTransactionExpired(tx)
           logger.info(
             "Transaction ${tx.transactionId.value()} in status ${tx.status}, refundable: $refundable, expired: $isTransactionExpired")
           if (!isTransactionExpired) {
             updateTransactionToExpired(
-              tx,
-              transactionsExpiredEventStoreRepository,
-              transactionsViewRepository,
-              wasAuthorizationRequested)
+              tx, transactionsExpiredEventStoreRepository, transactionsViewRepository)
           } else {
             Mono.just(tx)
           }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumerTests.kt
@@ -1256,7 +1256,7 @@ class TransactionExpirationQueueConsumerTests {
   }
 
   @Test
-  fun `messageReceiver calls update transaction to CANCELLATION_REQUESTED for transaction expired in CANCELLATION_REQUESTED status`() =
+  fun `messageReceiver calls update transaction to CANCELLATION_EXPIRED for transaction expired in CANCELLATION_REQUESTED status`() =
     runTest {
       val transactionExpirationQueueConsumer =
         TransactionExpirationQueueConsumer(
@@ -1323,7 +1323,7 @@ class TransactionExpirationQueueConsumerTests {
     }
 
   @Test
-  fun `messageReceiver calls update transaction to CANCELLATION_REQUESTED for transaction expired in CLOSURE_ERROR coming from user cancellation`() =
+  fun `messageReceiver calls update transaction to CANCELLATION_EXPIRED for transaction expired in CLOSURE_ERROR coming from user cancellation`() =
     runTest {
       val transactionExpirationQueueConsumer =
         TransactionExpirationQueueConsumer(
@@ -1392,7 +1392,7 @@ class TransactionExpirationQueueConsumerTests {
     }
 
   @Test
-  fun `messageReceiver does nothing on a expiration event received for a transaction in CANCELLATION_REQUESTED status`() =
+  fun `messageReceiver does nothing on a expiration event received for a transaction in CANCELLATION_EXPIRED status`() =
     runTest {
       val transactionExpirationQueueConsumer =
         TransactionExpirationQueueConsumer(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add handling for `CANCELLATION_EXPIRED` expiration status.
Into this status a transaction can come for a transaction expired in CANCELLATION_REQUESTED status or from expiration into CLOSURE_ERROR status for a transaction canceled by user
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to update expiration status accordingly to the fact that transaction was cancelled by user or not
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit test and local tests with ecommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.