### PR TITLE
fix: no refund for trx with send payment result OK

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/common.kt
@@ -241,7 +241,7 @@ fun isTransactionRefundable(tx: BaseTransaction): Boolean {
   val isTransactionRefundable =
     wasAuthorizationRequested && !wasSendPaymentResultOutcomeOK && !wasAuthorizationDenied
   logger.info(
-    "Transaction with if ${tx.transactionId} : was authorization requested: $wasAuthorizationRequested, was authorization denied: $wasAuthorizationDenied, was send payment result outcome OK : $wasSendPaymentResultOutcomeOK --> is refundable: $isTransactionRefundable")
+    "Transaction with id ${tx.transactionId.value()} : was authorization requested: $wasAuthorizationRequested, was authorization denied: $wasAuthorizationDenied, was send payment result outcome OK : $wasSendPaymentResultOutcomeOK --> is refundable: $isTransactionRefundable")
   return isTransactionRefundable
 }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/TransactionExpirationQueueConsumerTests.kt
@@ -778,7 +778,7 @@ class TransactionExpirationQueueConsumerTests {
     }
 
   @Test
-  fun `messageReceiver calls refund on transaction with NOTIFIED_KO`() = runTest {
+  fun `messageReceiver calls refund on transaction expired in NOTIFIED_KO status`() = runTest {
     val transactionExpirationQueueConsumer =
       TransactionExpirationQueueConsumer(
         paymentGatewayClient,
@@ -788,18 +788,15 @@ class TransactionExpirationQueueConsumerTests {
         transactionsViewRepository,
         transactionUtils,
         refundRetryService)
-
+    val transactionUserReceiptData =
+      transactionUserReceiptData(TransactionUserReceiptData.Outcome.KO)
     val activatedEvent = transactionActivateEvent()
     val authorizationRequestedEvent = transactionAuthorizationRequestedEvent()
     val authorizationCompletedEvent =
       transactionAuthorizationCompletedEvent(AuthorizationResultDto.OK)
     val closedEvent = transactionClosedEvent(TransactionClosureData.Outcome.OK)
-    val userReceiptRequestedEvent =
-      transactionUserReceiptRequestedEvent(
-        transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK))
-    val addUserReceiptEvent =
-      transactionUserReceiptAddedEvent(
-        transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK))
+    val userReceiptRequestedEvent = transactionUserReceiptRequestedEvent(transactionUserReceiptData)
+    val addUserReceiptEvent = transactionUserReceiptAddedEvent(transactionUserReceiptData)
     val expiredEvent =
       transactionExpiredEvent(
         reduceEvents(
@@ -1091,6 +1088,215 @@ class TransactionExpirationQueueConsumerTests {
       assertEquals(TransactionEventCode.TRANSACTION_EXPIRED_EVENT, expiredEvent.eventCode)
       assertEquals(
         TransactionStatusDto.NOTIFICATION_ERROR, expiredEvent.data.statusBeforeExpiration)
+    }
+
+  @Test
+  fun `messageReceiver calls refund on transaction expired in NOTIFICATION_ERROR status and send payment result outcome KO`() =
+    runTest {
+      val transactionExpirationQueueConsumer =
+        TransactionExpirationQueueConsumer(
+          paymentGatewayClient,
+          transactionsEventStoreRepository,
+          transactionsExpiredEventStoreRepository,
+          transactionsRefundedEventStoreRepository,
+          transactionsViewRepository,
+          transactionUtils,
+          refundRetryService)
+      val transactionUserReceiptData =
+        transactionUserReceiptData(TransactionUserReceiptData.Outcome.KO)
+      val activatedEvent = transactionActivateEvent()
+      val authorizationRequestedEvent = transactionAuthorizationRequestedEvent()
+      val authorizationCompletedEvent =
+        transactionAuthorizationCompletedEvent(AuthorizationResultDto.OK)
+      val closedEvent = transactionClosedEvent(TransactionClosureData.Outcome.OK)
+      val userReceiptRequestedEvent =
+        transactionUserReceiptRequestedEvent(transactionUserReceiptData)
+      val userReceiptErrorEvent = transactionUserReceiptAddErrorEvent(transactionUserReceiptData)
+      val expiredEvent =
+        transactionExpiredEvent(
+          reduceEvents(
+            activatedEvent,
+            authorizationRequestedEvent,
+            authorizationCompletedEvent,
+            closedEvent,
+            userReceiptRequestedEvent,
+            userReceiptErrorEvent))
+      val gatewayClientResponse = VposDeleteResponseDto()
+      gatewayClientResponse.status(VposDeleteResponseDto.StatusEnum.CANCELLED)
+
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionId(
+            any(),
+          ))
+        .willReturn(
+          Flux.just(
+            activatedEvent as TransactionEvent<Any>,
+            authorizationRequestedEvent as TransactionEvent<Any>,
+            authorizationCompletedEvent as TransactionEvent<Any>,
+            closedEvent as TransactionEvent<Any>,
+            userReceiptRequestedEvent as TransactionEvent<Any>,
+            userReceiptErrorEvent as TransactionEvent<Any>,
+            expiredEvent as TransactionEvent<Any>))
+
+      given(
+          transactionsExpiredEventStoreRepository.save(
+            transactionExpiredEventStoreCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            transactionRefundEventStoreCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(TransactionStatusDto.NOTIFICATION_ERROR, ZonedDateTime.now())),
+            Mono.just(transactionDocument(TransactionStatusDto.EXPIRED, ZonedDateTime.now())),
+            Mono.just(
+              transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()))))
+      given(transactionsViewRepository.save(transactionViewRepositoryCaptor.capture())).willAnswer {
+        Mono.just(it.arguments[0])
+      }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(Mono.just(gatewayClientResponse))
+
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(TransactionStatusDto.NOTIFICATION_ERROR, ZonedDateTime.now())),
+            Mono.just(transactionDocument(TransactionStatusDto.EXPIRED, ZonedDateTime.now())),
+            Mono.just(
+              transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()))))
+
+      /* test */
+      StepVerifier.create(
+          transactionExpirationQueueConsumer.messageReceiver(
+            BinaryData.fromObject(activatedEvent).toBytes(), checkpointer))
+        .expectNext()
+        .expectComplete()
+        .verify()
+
+      /* Asserts */
+      verify(checkpointer, times(1)).success()
+      verify(transactionsExpiredEventStoreRepository, times(0)).save(any())
+      verify(paymentGatewayClient, times(1)).requestVPosRefund(any())
+      verify(transactionsRefundedEventStoreRepository, times(2)).save(any())
+      verify(transactionsViewRepository, times(2)).save(any())
+      /*
+       * check view update statuses and events stored into event store
+       */
+      val expectedRefundEventStatuses =
+        listOf(
+          TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT)
+      val viewExpectedStatuses =
+        listOf(TransactionStatusDto.REFUND_REQUESTED, TransactionStatusDto.REFUNDED)
+      viewExpectedStatuses.forEachIndexed { idx, expectedStatus ->
+        assertEquals(
+          expectedStatus,
+          transactionViewRepositoryCaptor.allValues[idx].status,
+          "Unexpected view status on idx: $idx")
+      }
+
+      expectedRefundEventStatuses.forEachIndexed { idx, expectedStatus ->
+        assertEquals(
+          expectedStatus,
+          transactionRefundEventStoreCaptor.allValues[idx].eventCode,
+          "Unexpected event code on idx: $idx")
+      }
+    }
+
+  @Test
+  fun `messageReceiver should not calls refund on transaction expired in NOTIFICATION_ERROR status and send payment result outcome OK`() =
+    runTest {
+      val transactionExpirationQueueConsumer =
+        TransactionExpirationQueueConsumer(
+          paymentGatewayClient,
+          transactionsEventStoreRepository,
+          transactionsExpiredEventStoreRepository,
+          transactionsRefundedEventStoreRepository,
+          transactionsViewRepository,
+          transactionUtils,
+          refundRetryService)
+      val transactionUserReceiptData =
+        transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK)
+      val activatedEvent = transactionActivateEvent()
+      val authorizationRequestedEvent = transactionAuthorizationRequestedEvent()
+      val authorizationCompletedEvent =
+        transactionAuthorizationCompletedEvent(AuthorizationResultDto.OK)
+      val closedEvent = transactionClosedEvent(TransactionClosureData.Outcome.OK)
+      val userReceiptRequestedEvent =
+        transactionUserReceiptRequestedEvent(transactionUserReceiptData)
+      val userReceiptErrorEvent = transactionUserReceiptAddErrorEvent(transactionUserReceiptData)
+      val expiredEvent =
+        transactionExpiredEvent(
+          reduceEvents(
+            activatedEvent,
+            authorizationRequestedEvent,
+            authorizationCompletedEvent,
+            closedEvent,
+            userReceiptRequestedEvent,
+            userReceiptErrorEvent,
+          ))
+      val gatewayClientResponse = VposDeleteResponseDto()
+      gatewayClientResponse.status(VposDeleteResponseDto.StatusEnum.CANCELLED)
+
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionId(
+            any(),
+          ))
+        .willReturn(
+          Flux.just(
+            activatedEvent as TransactionEvent<Any>,
+            authorizationRequestedEvent as TransactionEvent<Any>,
+            authorizationCompletedEvent as TransactionEvent<Any>,
+            closedEvent as TransactionEvent<Any>,
+            userReceiptRequestedEvent as TransactionEvent<Any>,
+            userReceiptErrorEvent as TransactionEvent<Any>,
+            expiredEvent as TransactionEvent<Any>))
+
+      given(
+          transactionsExpiredEventStoreRepository.save(
+            transactionExpiredEventStoreCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            transactionRefundEventStoreCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(transactionsViewRepository.save(transactionViewRepositoryCaptor.capture())).willAnswer {
+        Mono.just(it.arguments[0])
+      }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(Mono.just(gatewayClientResponse))
+
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(TransactionStatusDto.NOTIFICATION_ERROR, ZonedDateTime.now())),
+            Mono.just(transactionDocument(TransactionStatusDto.EXPIRED, ZonedDateTime.now())),
+            Mono.just(
+              transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()))))
+
+      /* test */
+      StepVerifier.create(
+          transactionExpirationQueueConsumer.messageReceiver(
+            BinaryData.fromObject(activatedEvent).toBytes(), checkpointer))
+        .expectNext()
+        .expectComplete()
+        .verify()
+
+      /* Asserts */
+      verify(checkpointer, times(1)).success()
+      verify(transactionsExpiredEventStoreRepository, times(0)).save(any())
+      verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+      verify(transactionsRefundedEventStoreRepository, times(0)).save(any())
+      verify(transactionsViewRepository, times(0)).save(any())
     }
 
   @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Fixed refund logic for transaction stuck in NOTIFICATION_REQUESTED or NOTIFICATATION_ERROR statuses.
For those transaction refund has to be performed only if the sendPaymentResult outcome received is KO
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification are needed in order to not perform refund for transaction expired in NOTIFICATION_REQUESTED or NOTIFICATION_ERROR statuses if the send payment result outcome is OK
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local tests with ecommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.