### PR TITLE
feat(close payment) added fields into transactionDetails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,9 +479,9 @@
 				<configuration>
 					<skipCheckoutIfExists>false</skipCheckoutIfExists>
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-					<scmVersionType>branch</scmVersionType>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -480,8 +480,8 @@
 					<skipCheckoutIfExists>false</skipCheckoutIfExists>
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>branch</scmVersionType>
-					<scmVersion>CHK-1674-add-pspOnUs-flag</scmVersion>
-					<goals>install -DskipTests</goals>
+					<scmVersionType>tag</scmVersionType>
+					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>0.18.2</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>0.18.3</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**
 		</sonar.coverage.exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
 						</goals>
 						<configuration>
 							<inputSpec>
-								https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-1674-closepaymentV2-update-biz-event/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl
+								https://raw.githubusercontent.com/pagopa/pagopa-infra/df87697f23ac384723c9c63f33201b277a9d59dc/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl
 							</inputSpec>
 							<generatorName>java</generatorName>
 							<library>webclient</library>

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
 						</goals>
 						<configuration>
 							<inputSpec>
-								https://raw.githubusercontent.com/pagopa/pagopa-infra/closepaymentv2-alignement/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl
+								https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-1674-closepaymentV2-update-biz-event/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl
 							</inputSpec>
 							<generatorName>java</generatorName>
 							<library>webclient</library>
@@ -479,8 +479,8 @@
 				<configuration>
 					<skipCheckoutIfExists>false</skipCheckoutIfExists>
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-					<scmVersionType>tag</scmVersionType>
-					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+					<scmVersion>CHK-1674-add-pspOnUs-flag</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
@@ -40,12 +40,6 @@ class NodeService(
 ) {
   var logger: Logger = LoggerFactory.getLogger(NodeService::class.java)
 
-  companion object {
-    const val CASTING_ERROR = "Unexpected transactionAtPreviousStep:"
-    const val CASTING_ERROR_TRANSACTION_WITH_CLOSURE_ERROR =
-      "Unexpected error while casting request into TransactionWithClosureError"
-  }
-
   suspend fun closePayment(
     transactionId: TransactionId,
     transactionOutcome: ClosePaymentRequestV2Dto.OutcomeEnum
@@ -83,9 +77,13 @@ class NodeService(
                     }
                   }
                 }
-                .orElseThrow { RuntimeException(CASTING_ERROR + it.transactionAtPreviousState) }
+                .orElseThrow {
+                  RuntimeException(
+                    "Unexpected transactionAtPreviousStep: ${it.transactionAtPreviousState} ")
+                }
             } else {
-              throw RuntimeException(CASTING_ERROR_TRANSACTION_WITH_CLOSURE_ERROR)
+              throw RuntimeException(
+                "Unexpected error while casting request into TransactionWithClosureError")
             }
           }
           TransactionStatusDto.CANCELLATION_REQUESTED ->

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
@@ -65,7 +65,7 @@ class NodeService(
                             transactionWithCancellation, transactionOutcome, transactionId)
                         },
                         { transactionWithCompletedAuthorization ->
-                          buildClosePaymentRequest(
+                          buildAuthorizationCompletedClosePaymentRequest(
                             transactionWithCompletedAuthorization,
                             transactionOutcome,
                             transactionId)
@@ -73,7 +73,8 @@ class NodeService(
                     }
                     ClosePaymentRequestV2Dto.OutcomeEnum.OK -> {
                       val authCompleted = trxPreviousStatus.get()
-                      buildClosePaymentRequest(authCompleted, transactionOutcome, transactionId)
+                      buildAuthorizationCompletedClosePaymentRequest(
+                        authCompleted, transactionOutcome, transactionId)
                     }
                   }
                 }
@@ -154,7 +155,7 @@ class NodeService(
     }
   }
 
-  private fun buildClosePaymentRequest(
+  private fun buildAuthorizationCompletedClosePaymentRequest(
     authCompleted: BaseTransactionWithCompletedAuthorization,
     transactionOutcome: ClosePaymentRequestV2Dto.OutcomeEnum,
     transactionId: TransactionId

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
@@ -59,9 +59,9 @@ class NodeService(
       baseTransaction.map {
         when (it.status) {
           TransactionStatusDto.CLOSURE_ERROR -> {
-            when (transactionOutcome) {
-              ClosePaymentRequestV2Dto.OutcomeEnum.KO -> {
-                if (it is TransactionWithClosureError) {
+            if (it is TransactionWithClosureError) {
+              when (transactionOutcome) {
+                ClosePaymentRequestV2Dto.OutcomeEnum.KO -> {
                   val transactionAtPreviousState = it.transactionAtPreviousState()
                   transactionAtPreviousState
                     .map { trx ->
@@ -78,12 +78,8 @@ class NodeService(
                         })
                     }
                     .orElseThrow { RuntimeException(CASTING_ERROR + it.transactionAtPreviousState) }
-                } else {
-                  throw RuntimeException(CASTING_ERROR_TRANSACTION_WITH_CLOSURE_ERROR)
                 }
-              }
-              ClosePaymentRequestV2Dto.OutcomeEnum.OK ->
-                if (it is TransactionWithClosureError) {
+                ClosePaymentRequestV2Dto.OutcomeEnum.OK -> {
                   val transactionAtPreviousState = it.transactionAtPreviousState()
                   transactionAtPreviousState
                     .map { event ->
@@ -91,9 +87,10 @@ class NodeService(
                       buildClosePaymentOKRequest(authCompleted, transactionOutcome, transactionId)
                     }
                     .orElseThrow { RuntimeException(CASTING_ERROR + it.transactionAtPreviousState) }
-                } else {
-                  throw RuntimeException(CASTING_ERROR_TRANSACTION_WITH_CLOSURE_ERROR)
                 }
+              }
+            } else {
+              throw RuntimeException(CASTING_ERROR_TRANSACTION_WITH_CLOSURE_ERROR)
             }
           }
           TransactionStatusDto.CANCELLATION_REQUESTED ->

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
@@ -172,7 +172,7 @@ class NodeService(
         EuroUtils.euroCentsToEuro(
           (authCompleted.transactionAuthorizationRequestData.amount.plus(
             authCompleted.transactionAuthorizationRequestData.fee)))
-      fee = authCompleted.transactionAuthorizationRequestData.fee.toBigDecimal()
+      fee = EuroUtils.euroCentsToEuro(authCompleted.transactionAuthorizationRequestData.fee)
       this.timestampOperation =
         OffsetDateTime.parse(
           authCompleted.transactionAuthorizationCompletedData.timestampOperation,
@@ -210,12 +210,13 @@ class NodeService(
               this.transactionId = transactionId.value()
               transactionStatus = getTransactionDetailsStatus(authCompleted)
               paymentGateway = authCompleted.transactionAuthorizationRequestData.paymentGateway.name
-              fee = authCompleted.transactionAuthorizationRequestData.fee.toBigDecimal()
-              amount = authCompleted.transactionAuthorizationRequestData.amount.toBigDecimal()
+              fee = EuroUtils.euroCentsToEuro(authCompleted.transactionAuthorizationRequestData.fee)
+              amount =
+                EuroUtils.euroCentsToEuro(authCompleted.transactionAuthorizationRequestData.amount)
               grandTotal =
-                (authCompleted.transactionAuthorizationRequestData.amount.plus(
-                    authCompleted.transactionAuthorizationRequestData.fee))
-                  .toBigDecimal()
+                EuroUtils.euroCentsToEuro(
+                  (authCompleted.transactionAuthorizationRequestData.amount.plus(
+                    authCompleted.transactionAuthorizationRequestData.fee)))
               rrn = authCompleted.transactionAuthorizationCompletedData.rrn
               errorCode =
                 if (transactionOutcome == ClosePaymentRequestV2Dto.OutcomeEnum.KO)

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeService.kt
@@ -62,7 +62,7 @@ class NodeService(
                       trxPreviousStatus.fold(
                         { transactionWithCancellation ->
                           buildClosePaymentForCancellationRequest(
-                            transactionWithCancellation, transactionOutcome, transactionId)
+                            transactionWithCancellation, transactionId)
                         },
                         { transactionWithCompletedAuthorization ->
                           buildAuthorizationCompletedClosePaymentRequest(
@@ -89,7 +89,7 @@ class NodeService(
           }
           TransactionStatusDto.CANCELLATION_REQUESTED ->
             buildClosePaymentForCancellationRequest(
-              it as BaseTransactionWithCancellationRequested, transactionOutcome, transactionId)
+              it as BaseTransactionWithCancellationRequested, transactionId)
           else -> {
             throw BadTransactionStatusException(
               transactionId = it.transactionId,
@@ -122,7 +122,6 @@ class NodeService(
 
   private fun buildClosePaymentForCancellationRequest(
     transactionWithCancellation: BaseTransactionWithCancellationRequested,
-    transactionOutcome: ClosePaymentRequestV2Dto.OutcomeEnum,
     transactionId: TransactionId
   ): ClosePaymentRequestV2Dto {
     val amount =
@@ -133,7 +132,7 @@ class NodeService(
           .sum())
     return ClosePaymentRequestV2Dto().apply {
       paymentTokens = transactionWithCancellation.paymentNotices.map { el -> el.paymentToken.value }
-      outcome = transactionOutcome
+      outcome = ClosePaymentRequestV2Dto.OutcomeEnum.KO
       this.transactionId = transactionId.value()
       transactionDetails =
         TransactionDetailsDto().apply {

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
@@ -14,7 +14,6 @@ import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto.OutcomeEnum
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto
 import it.pagopa.generated.ecommerce.nodo.v2.dto.UserDto
-import java.math.BigDecimal
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -218,13 +217,13 @@ class NodeServiceTests {
       assertEquals(
         transactionId, closePaymentRequestCaptor.value.transactionDetails.transaction.transactionId)
       assertEquals(
-        BigDecimal(authEvent.data.fee),
+        EuroUtils.euroCentsToEuro(authEvent.data.fee),
         closePaymentRequestCaptor.value.transactionDetails.transaction.fee)
       assertEquals(
-        BigDecimal(authEvent.data.amount),
+        EuroUtils.euroCentsToEuro(authEvent.data.amount),
         closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
       assertEquals(
-        BigDecimal(authEvent.data.fee).add(BigDecimal(authEvent.data.amount)),
+        EuroUtils.euroCentsToEuro(authEvent.data.fee.plus(authEvent.data.amount)),
         closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertEquals(
         authCompletedEvent.data.authorizationCode,
@@ -323,13 +322,13 @@ class NodeServiceTests {
       assertEquals(
         transactionId, closePaymentRequestCaptor.value.transactionDetails.transaction.transactionId)
       assertEquals(
-        BigDecimal(authEvent.data.fee),
+        EuroUtils.euroCentsToEuro(authEvent.data.fee),
         closePaymentRequestCaptor.value.transactionDetails.transaction.fee)
       assertEquals(
-        BigDecimal(authEvent.data.amount),
+        EuroUtils.euroCentsToEuro(authEvent.data.amount),
         closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
       assertEquals(
-        BigDecimal(authEvent.data.fee).add(BigDecimal(authEvent.data.amount)),
+        EuroUtils.euroCentsToEuro(authEvent.data.fee.plus(authEvent.data.amount)),
         closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertEquals(
         authCompletedEvent.data.errorCode,

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
@@ -71,15 +71,28 @@ class NodeServiceTests {
       assertEquals(
         closePaymentResponse,
         nodeService.closePayment(TransactionId(transactionId), transactionOutcome))
+
+      assertEquals(transactionId, closePaymentRequestCaptor.value.transactionId)
+      assertEquals(OutcomeEnum.KO, closePaymentRequestCaptor.value.outcome)
+      // check additionalPaymentInformations
+      assertNull(closePaymentRequestCaptor.value.additionalPaymentInformations)
+      // check transactionDetails
       assertEquals(
-        "Annullato",
+        UserDto.TypeEnum.GUEST, closePaymentRequestCaptor.value.transactionDetails.user.type)
+      assertEquals(
+        TransactionDetailsStatusEnum.TRANSACTION_DETAILS_STATUS_CANCELED.status,
         closePaymentRequestCaptor.value.transactionDetails.transaction.transactionStatus)
       assertEquals(
         Transaction.ClientId.CHECKOUT.name,
         closePaymentRequestCaptor.value.transactionDetails.info.clientId)
+      assertEquals(TIPO_VERSAMENTO_CP, closePaymentRequestCaptor.value.transactionDetails.info.type)
+      assertEquals(
+        closePaymentRequestCaptor.value.transactionDetails.transaction.amount,
+        closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertNull(closePaymentRequestCaptor.value.transactionDetails.transaction.fee)
-      assertNull(closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
+      assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
+      assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.creationDate)
     }
 
   @Test
@@ -110,15 +123,28 @@ class NodeServiceTests {
       assertEquals(
         closePaymentResponse,
         nodeService.closePayment(TransactionId(transactionId), transactionOutcome))
+
+      assertEquals(transactionId, closePaymentRequestCaptor.value.transactionId)
+      assertEquals(OutcomeEnum.KO, closePaymentRequestCaptor.value.outcome)
+      // check additionalPaymentInformations
+      assertNull(closePaymentRequestCaptor.value.additionalPaymentInformations)
+      // check transactionDetails
       assertEquals(
-        "Annullato",
+        UserDto.TypeEnum.GUEST, closePaymentRequestCaptor.value.transactionDetails.user.type)
+      assertEquals(
+        TransactionDetailsStatusEnum.TRANSACTION_DETAILS_STATUS_CANCELED.status,
         closePaymentRequestCaptor.value.transactionDetails.transaction.transactionStatus)
       assertEquals(
         Transaction.ClientId.CHECKOUT.name,
         closePaymentRequestCaptor.value.transactionDetails.info.clientId)
+      assertEquals(TIPO_VERSAMENTO_CP, closePaymentRequestCaptor.value.transactionDetails.info.type)
+      assertEquals(
+        closePaymentRequestCaptor.value.transactionDetails.transaction.amount,
+        closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertNull(closePaymentRequestCaptor.value.transactionDetails.transaction.fee)
-      assertNull(closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
+      assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
+      assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.creationDate)
     }
 
   @Test

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
@@ -53,7 +53,9 @@ class NodeServiceTests {
       val canceledEvent = transactionUserCanceledEvent()
       val events = listOf(activatedEvent, canceledEvent) as List<TransactionEvent<Any>>
       val transactionId = activatedEvent.transactionId
-
+      val amount =
+        EuroUtils.euroCentsToEuro(
+          activatedEvent.data.paymentNotices.stream().mapToInt { el -> el.amount }.sum())
       val closePaymentResponse =
         ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.OK }
 
@@ -91,6 +93,9 @@ class NodeServiceTests {
       assertNull(closePaymentRequestCaptor.value.transactionDetails.transaction.fee)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
+      assertEquals(amount, closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
+      assertEquals(
+        amount, closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.creationDate)
     }
 
@@ -106,6 +111,9 @@ class NodeServiceTests {
       val events =
         listOf(activatedEvent, canceledEvent, closureError) as List<TransactionEvent<Any>>
       val transactionId = activatedEvent.transactionId
+      val amount =
+        EuroUtils.euroCentsToEuro(
+          activatedEvent.data.paymentNotices.stream().mapToInt { el -> el.amount }.sum())
 
       val closePaymentResponse =
         ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.OK }
@@ -143,6 +151,9 @@ class NodeServiceTests {
       assertNull(closePaymentRequestCaptor.value.transactionDetails.transaction.fee)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
+      assertEquals(amount, closePaymentRequestCaptor.value.transactionDetails.transaction.amount)
+      assertEquals(
+        amount, closePaymentRequestCaptor.value.transactionDetails.transaction.grandTotal)
       assertNotNull(closePaymentRequestCaptor.value.transactionDetails.transaction.creationDate)
     }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
@@ -71,6 +71,7 @@ class NodeServiceTests {
       assertEquals(
         closePaymentResponse,
         nodeService.closePayment(TransactionId(transactionId), transactionOutcome))
+      println("ressss" + closePaymentRequestCaptor.value)
       assertEquals(
         "Annullato",
         closePaymentRequestCaptor.value.transactionDetails.transaction.transactionStatus)
@@ -91,7 +92,8 @@ class NodeServiceTests {
       val canceledEvent = transactionUserCanceledEvent()
       val closureError = transactionClosureErrorEvent()
 
-      val events = listOf(activatedEvent, canceledEvent, closureError) as List<TransactionEvent<Any>>
+      val events =
+        listOf(activatedEvent, canceledEvent, closureError) as List<TransactionEvent<Any>>
       val transactionId = activatedEvent.transactionId
 
       val closePaymentResponse =
@@ -105,9 +107,10 @@ class NodeServiceTests {
 
       given(nodeClient.closePayment(capture(closePaymentRequestCaptor)))
         .willReturn(Mono.just(closePaymentResponse))
-      val response = nodeService.closePayment(TransactionId(transactionId), transactionOutcome)
       /* test */
-      assertEquals(closePaymentResponse, response)
+      assertEquals(
+        closePaymentResponse,
+        nodeService.closePayment(TransactionId(transactionId), transactionOutcome))
       assertEquals(
         "Annullato",
         closePaymentRequestCaptor.value.transactionDetails.transaction.transactionStatus)
@@ -284,6 +287,7 @@ class NodeServiceTests {
         closePaymentRequestCaptor.value.transactionDetails.info.type)
 
       // Check additionalPaymentInfo
+      println("eccolo" + closePaymentRequestCaptor.value)
       assertNull(closePaymentRequestCaptor.value.additionalPaymentInformations)
     }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/NodeServiceTests.kt
@@ -71,7 +71,6 @@ class NodeServiceTests {
       assertEquals(
         closePaymentResponse,
         nodeService.closePayment(TransactionId(transactionId), transactionOutcome))
-      println("ressss" + closePaymentRequestCaptor.value)
       assertEquals(
         "Annullato",
         closePaymentRequestCaptor.value.transactionDetails.transaction.transactionStatus)
@@ -287,7 +286,6 @@ class NodeServiceTests {
         closePaymentRequestCaptor.value.transactionDetails.info.type)
 
       // Check additionalPaymentInfo
-      println("eccolo" + closePaymentRequestCaptor.value)
       assertNull(closePaymentRequestCaptor.value.additionalPaymentInformations)
     }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
@@ -28,6 +28,7 @@ fun getMockedClosePaymentRequest(
       "pspChannelCode",
       "requestId",
       "pspBusinessName",
+      false,
       "authorizationRequestId",
       TransactionAuthorizationRequestData.PaymentGateway.VPOS,
       TransactionTestUtils.LOGO_URI,


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/95
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

👉🏻 **CLOSE PAYMENT OK/KO with authorization completation event** 

Changed the logic to forward the close payment to the node. 
The following fields have been added to the `transactionDetails` object in case of close payment **OK** or **KO** after receiving the request for completion of authorization: 

- brand
- paymentMethodName
- clientId
- errorCode
- timestampOperation
- brokerName
- paymentGateway
- pspOnUs

The field `authorizationCode` will be valorized only in case of close payment **OK** otherwise in case of **KO** the `errorCode` will be valorized.

👉🏻 **CLOSE PAYMENT KO with user cancellation request**

in case of closePayment KO for cancellation by the user will be forwarded only new fields available in the `transactionDetail` field in particular: 

- clientId
- timestampOperation


<!--- Describe your changes in detail -->

#### Motivation and Context
The change was made to enhance with the correct information the `transactionDetails` field in the closePayment request to the node 🚀
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
The tests were carried out with junit test and running a flow with ecommerce-local 📈
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.