### PR TITLE
[CHK-1589] fix closePayment retry logic

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClient.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClient.kt
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.eventdispatcher.client
 
+import it.pagopa.ecommerce.eventdispatcher.exceptions.BadClosePaymentRequest
 import it.pagopa.ecommerce.eventdispatcher.exceptions.BadGatewayException
 import it.pagopa.ecommerce.eventdispatcher.exceptions.GatewayTimeoutException
 import it.pagopa.ecommerce.eventdispatcher.exceptions.TransactionNotFound
@@ -34,6 +35,7 @@ class NodeClient(@Autowired private val nodeApi: NodoApi) {
         throw when (exception.statusCode) {
           HttpStatus.NOT_FOUND ->
             TransactionNotFound(UUID.fromString(closePaymentRequest.transactionId))
+          HttpStatus.BAD_REQUEST -> BadClosePaymentRequest("")
           HttpStatus.REQUEST_TIMEOUT -> GatewayTimeoutException()
           HttpStatus.INTERNAL_SERVER_ERROR -> BadGatewayException("")
           else -> exception

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/BadClosePaymentRequest.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/exceptions/BadClosePaymentRequest.kt
@@ -1,0 +1,8 @@
+package it.pagopa.ecommerce.eventdispatcher.exceptions
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+class BadClosePaymentRequest(detail: String) :
+  RuntimeException("Bad closePayment request ${if (detail.isNotEmpty()) ": $detail" else ""}")


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
#### List of Changes
- Remove retry for unrecoverable errors (404 - TransactionNotFound, 400 - Bad request)

<!--- Describe your changes in detail -->
#### Motivation and Context
- A retry message will not be inserted in the retry queue when this unrecoverable errors are thrown

<!--- Why is this change required? What problem does it solve? -->
#### How Has This Been Tested?
- Remove useless retries
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.