### PR TITLE
fix(nodo client): transaction id parsing as domain object

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClient.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClient.kt
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.eventdispatcher.client
 
+import it.pagopa.ecommerce.commons.domain.v1.TransactionId
 import it.pagopa.ecommerce.eventdispatcher.exceptions.BadClosePaymentRequest
 import it.pagopa.ecommerce.eventdispatcher.exceptions.BadGatewayException
 import it.pagopa.ecommerce.eventdispatcher.exceptions.GatewayTimeoutException
@@ -7,7 +8,6 @@ import it.pagopa.ecommerce.eventdispatcher.exceptions.TransactionNotFound
 import it.pagopa.generated.ecommerce.nodo.v2.api.NodoApi
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto
-import java.util.*
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.mono
 import org.springframework.beans.factory.annotation.Autowired
@@ -34,7 +34,7 @@ class NodeClient(@Autowired private val nodeApi: NodoApi) {
       } catch (exception: WebClientResponseException) {
         throw when (exception.statusCode) {
           HttpStatus.NOT_FOUND ->
-            TransactionNotFound(UUID.fromString(closePaymentRequest.transactionId))
+            TransactionNotFound(TransactionId(closePaymentRequest.transactionId).uuid)
           HttpStatus.BAD_REQUEST -> BadClosePaymentRequest("")
           HttpStatus.REQUEST_TIMEOUT -> GatewayTimeoutException()
           HttpStatus.INTERNAL_SERVER_ERROR -> BadGatewayException("")

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClientTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClientTest.kt
@@ -1,5 +1,7 @@
 package it.pagopa.ecommerce.eventdispatcher.client
 
+import it.pagopa.ecommerce.commons.domain.v1.TransactionId
+import it.pagopa.ecommerce.commons.v1.TransactionTestUtils
 import it.pagopa.ecommerce.eventdispatcher.exceptions.BadClosePaymentRequest
 import it.pagopa.ecommerce.eventdispatcher.exceptions.BadGatewayException
 import it.pagopa.ecommerce.eventdispatcher.exceptions.GatewayTimeoutException
@@ -9,7 +11,6 @@ import it.pagopa.generated.ecommerce.nodo.v2.api.NodoApi
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto.OutcomeEnum
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto
 import java.nio.charset.Charset
-import java.util.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.test.runTest
@@ -33,12 +34,14 @@ class NodeClientTest {
   @Mock private lateinit var nodeApi: NodoApi
 
   @InjectMocks private lateinit var nodeClient: NodeClient
+
   companion object {
     const val CLOSE_PAYMENT_CLIENT_ID: String = "ecomm"
   }
+
   @Test
   fun `closePayment returns successfully`() = runTest {
-    val transactionId: UUID = UUID.randomUUID()
+    val transactionId = TransactionId(TransactionTestUtils.TRANSACTION_ID)
 
     val closePaymentRequest = getMockedClosePaymentRequest(transactionId, OutcomeEnum.OK)
     val expected =
@@ -56,7 +59,7 @@ class NodeClientTest {
 
   @Test
   fun `closePayment throws TransactionEventNotFoundException on Node 404`() = runTest {
-    val transactionId: UUID = UUID.randomUUID()
+    val transactionId = TransactionId(TransactionTestUtils.TRANSACTION_ID)
 
     val closePaymentRequest = getMockedClosePaymentRequest(transactionId, OutcomeEnum.OK)
 
@@ -73,7 +76,7 @@ class NodeClientTest {
 
   @Test
   fun `closePayment throws GatewayTimeoutException on Node 408`() = runTest {
-    val transactionId: UUID = UUID.randomUUID()
+    val transactionId = TransactionId(TransactionTestUtils.TRANSACTION_ID)
 
     val closePaymentRequest = getMockedClosePaymentRequest(transactionId, OutcomeEnum.OK)
 
@@ -92,7 +95,7 @@ class NodeClientTest {
 
   @Test
   fun `closePayment throws BadGatewayException on Node 500`() = runTest {
-    val transactionId: UUID = UUID.randomUUID()
+    val transactionId = TransactionId(TransactionTestUtils.TRANSACTION_ID)
 
     val closePaymentRequest = getMockedClosePaymentRequest(transactionId, OutcomeEnum.OK)
 
@@ -113,7 +116,7 @@ class NodeClientTest {
 
   @Test
   fun `closePayment throws BadClosePaymentRequest on Node 400`() = runTest {
-    val transactionId: UUID = UUID.randomUUID()
+    val transactionId = TransactionId(TransactionTestUtils.TRANSACTION_ID)
 
     val closePaymentRequest = getMockedClosePaymentRequest(transactionId, OutcomeEnum.OK)
 

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TestUtil.kt
@@ -4,6 +4,7 @@ import com.azure.core.http.rest.Response
 import com.azure.core.http.rest.ResponseBase
 import com.azure.storage.queue.models.SendMessageResult
 import it.pagopa.ecommerce.commons.documents.v1.TransactionAuthorizationRequestData
+import it.pagopa.ecommerce.commons.domain.v1.TransactionId
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils
 import it.pagopa.generated.ecommerce.gateway.v1.dto.VposDeleteResponseDto
 import it.pagopa.generated.ecommerce.gateway.v1.dto.XPayRefundResponse200Dto
@@ -13,7 +14,7 @@ import java.util.*
 import reactor.core.publisher.Mono
 
 fun getMockedClosePaymentRequest(
-  transactionId: UUID,
+  transactionId: TransactionId,
   outcome: ClosePaymentRequestV2Dto.OutcomeEnum
 ): ClosePaymentRequestV2Dto {
 
@@ -42,7 +43,7 @@ fun getMockedClosePaymentRequest(
     paymentMethod = authEventData.paymentTypeCode
     idBrokerPSP = authEventData.brokerName
     idChannel = authEventData.pspChannelCode
-    this.transactionId = transactionId.toString()
+    this.transactionId = transactionId.value()
     totalAmount = (authEventData.amount + authEventData.fee).toBigDecimal()
     timestampOperation = OffsetDateTime.now()
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Fix close payment transaction id parsing as TransactionId domain object 
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed because event transaction id does not contains dashes and cause unhandled exception in case of 404 Nodo error response
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.