### PR TITLE
fix: write event to dead letter queue for no left attempt

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -245,7 +245,7 @@ fun refundTransaction(
             // Enqueue retry event only if refund is allowed
             !is RefundNotAllowedException ->
               refundRetryService.enqueueRetryEvent(it, retryCount, tracingInfo)
-            else -> Mono.empty()
+            else -> Mono.error(exception)
           }
         }
         .thenReturn(tx)

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
@@ -979,4 +979,113 @@ class TransactionNotificationsRetryQueueConsumerTest {
         eq(Duration.ZERO),
         eq(Duration.ofSeconds(DEAD_LETTER_QUEUE_TTL_SECONDS.toLong())))
   }
+
+  @Test
+  fun `Should perform refund for no left attempts resending mail for send payment result KO and error writing event to dead letter queue`() =
+    runTest {
+      val attempt = 3
+      val transactionUserReceiptData =
+        transactionUserReceiptData(TransactionUserReceiptData.Outcome.KO)
+      val notificationErrorEvent = transactionUserReceiptAddErrorEvent(transactionUserReceiptData)
+      val notificationRetriedEvent = transactionUserReceiptAddRetriedEvent(attempt)
+      val events =
+        listOf(
+          transactionActivateEvent(),
+          transactionAuthorizationRequestedEvent(),
+          transactionAuthorizationCompletedEvent(
+            PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK)),
+          transactionClosedEvent(TransactionClosureData.Outcome.OK),
+          transactionUserReceiptRequestedEvent(transactionUserReceiptData),
+          notificationErrorEvent,
+          notificationRetriedEvent)
+          as List<TransactionEvent<Any>>
+      val baseTransaction =
+        reduceEvents(*events.toTypedArray()) as BaseTransactionWithRequestedUserReceipt
+      val transactionId = TRANSACTION_ID
+      val document =
+        transactionDocument(TransactionStatusDto.NOTIFICATION_ERROR, ZonedDateTime.now())
+      Hooks.onOperatorDebug()
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+            TRANSACTION_ID))
+        .willReturn(Flux.fromIterable(events))
+      given(userReceiptMailBuilder.buildNotificationEmailRequestDto(baseTransaction))
+        .willReturn(NotificationEmailRequestDto())
+      given(notificationsServiceClient.sendNotificationEmail(any()))
+        .willReturn(Mono.error(RuntimeException("Error calling notification service")))
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturn(Mono.just(document))
+      given(transactionsViewRepository.save(capture(transactionViewRepositoryCaptor))).willAnswer {
+        Mono.just(it.arguments[0])
+      }
+      given(transactionUserReceiptRepository.save(capture(transactionUserReceiptCaptor)))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(notificationRetryService.enqueueRetryEvent(any(), capture(retryCountCaptor), any()))
+        .willReturn(
+          Mono.error(
+            NoRetryAttemptsLeftException(
+              TransactionId(transactionId),
+              TransactionEventCode.TRANSACTION_ADD_USER_RECEIPT_ERROR_EVENT.toString())))
+      given(transactionRefundRepository.save(capture(transactionRefundEventStoreCaptor)))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(
+          Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(TransactionStatusDto.NOTIFICATION_ERROR, ZonedDateTime.now())),
+            Mono.just(transactionDocument(TransactionStatusDto.EXPIRED, ZonedDateTime.now())),
+            Mono.just(
+              transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()))))
+      given(
+          deadLetterQueueAsyncClient.sendMessageWithResponse(
+            queueArgumentCaptor.capture(), any(), anyOrNull()))
+        .willReturn(Mono.error(RuntimeException("Error writing event to dead letter queue")))
+      StepVerifier.create(
+          transactionNotificationsRetryQueueConsumer.messageReceiver(
+            Either.right(QueueEvent(notificationRetriedEvent, MOCK_TRACING_INFO)), checkpointer))
+        .expectNext(Unit)
+        .verifyComplete()
+      verify(checkpointer, times(1)).success()
+      verify(transactionsEventStoreRepository, times(1))
+        .findByTransactionIdOrderByCreationDateAsc(transactionId)
+      verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
+      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any())
+      verify(transactionsViewRepository, times(2)).save(any())
+      verify(transactionRefundRepository, times(2)).save(any())
+      verify(paymentGatewayClient, times(1)).requestVPosRefund(any())
+      verify(transactionUserReceiptRepository, times(0)).save(any())
+      verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      verify(userReceiptMailBuilder, times(1)).buildNotificationEmailRequestDto(baseTransaction)
+      assertEquals(
+        String(
+          jsonSerializerV2.serializeToBytes(
+            QueueEvent(notificationRetriedEvent, MOCK_TRACING_INFO)),
+          StandardCharsets.UTF_8),
+        String(queueArgumentCaptor.value.toBytes(), StandardCharsets.UTF_8))
+
+      assertEquals(attempt, retryCountCaptor.value)
+      val expectedStatuses =
+        listOf(TransactionStatusDto.REFUND_REQUESTED, TransactionStatusDto.REFUNDED)
+      val expectedEventCodes =
+        listOf(
+          TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT)
+      expectedEventCodes.forEachIndexed { index, eventCode ->
+        assertEquals(
+          eventCode,
+          TransactionEventCode.valueOf(
+            transactionRefundEventStoreCaptor.allValues[index].eventCode))
+        assertEquals(
+          TransactionStatusDto.NOTIFICATION_ERROR,
+          transactionRefundEventStoreCaptor.allValues[index].data.statusBeforeRefunded)
+      }
+      expectedStatuses.forEachIndexed { index, transactionStatus ->
+        assertEquals(transactionStatus, transactionViewRepositoryCaptor.allValues[index].status)
+      }
+    }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
@@ -908,6 +908,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionUserReceiptRepository, times(0)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
       verify(userReceiptMailBuilder, times(1)).buildNotificationEmailRequestDto(baseTransaction)
+      verify(deadLetterQueueAsyncClient, times(1))
+        .sendMessageWithResponse(any<BinaryData>(), any(), any())
       assertEquals(
         String(
           jsonSerializerV2.serializeToBytes(

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
@@ -31,6 +31,7 @@ import it.pagopa.ecommerce.eventdispatcher.utils.v2.UserReceiptMailBuilder
 import it.pagopa.generated.ecommerce.gateway.v1.dto.VposDeleteResponseDto
 import it.pagopa.generated.notifications.v1.dto.NotificationEmailRequestDto
 import it.pagopa.generated.notifications.v1.dto.NotificationEmailResponseDto
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.util.*
@@ -90,6 +91,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
     ArgumentCaptor<TransactionEvent<TransactionUserReceiptData>>
 
   @Captor private lateinit var retryCountCaptor: ArgumentCaptor<Int>
+
+  @Captor private lateinit var queueArgumentCaptor: ArgumentCaptor<BinaryData>
 
   private val deadLetterQueueAsyncClient: QueueAsyncClient = mock()
   private val strictJsonSerializerProviderV2 = QueuesConsumerConfig().strictSerializerProviderV2()
@@ -793,7 +796,10 @@ class TransactionNotificationsRetryQueueConsumerTest {
             Mono.just(transactionDocument(TransactionStatusDto.EXPIRED, ZonedDateTime.now())),
             Mono.just(
               transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()))))
-
+      given(
+          deadLetterQueueAsyncClient.sendMessageWithResponse(
+            queueArgumentCaptor.capture(), any(), anyOrNull()))
+        .willReturn(queueSuccessfulResponse())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
             Either.right(QueueEvent(notificationRetriedEvent, MOCK_TRACING_INFO)), checkpointer))
@@ -810,7 +816,15 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionUserReceiptRepository, times(0)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
       verify(userReceiptMailBuilder, times(1)).buildNotificationEmailRequestDto(baseTransaction)
+      verify(deadLetterQueueAsyncClient, times(1))
+        .sendMessageWithResponse(any<BinaryData>(), any(), any())
       assertEquals(attempt, retryCountCaptor.value)
+      assertEquals(
+        String(
+          jsonSerializerV2.serializeToBytes(
+            QueueEvent(notificationRetriedEvent, MOCK_TRACING_INFO)),
+          StandardCharsets.UTF_8),
+        String(queueArgumentCaptor.value.toBytes(), StandardCharsets.UTF_8))
     }
 
   @Test
@@ -874,6 +888,10 @@ class TransactionNotificationsRetryQueueConsumerTest {
             Mono.just(transactionDocument(TransactionStatusDto.EXPIRED, ZonedDateTime.now())),
             Mono.just(
               transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()))))
+      given(
+          deadLetterQueueAsyncClient.sendMessageWithResponse(
+            queueArgumentCaptor.capture(), any(), anyOrNull()))
+        .willReturn(queueSuccessfulResponse())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
             Either.right(QueueEvent(notificationRetriedEvent, MOCK_TRACING_INFO)), checkpointer))
@@ -890,6 +908,13 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionUserReceiptRepository, times(0)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
       verify(userReceiptMailBuilder, times(1)).buildNotificationEmailRequestDto(baseTransaction)
+      assertEquals(
+        String(
+          jsonSerializerV2.serializeToBytes(
+            QueueEvent(notificationRetriedEvent, MOCK_TRACING_INFO)),
+          StandardCharsets.UTF_8),
+        String(queueArgumentCaptor.value.toBytes(), StandardCharsets.UTF_8))
+
       assertEquals(attempt, retryCountCaptor.value)
       val expectedStatuses =
         listOf(TransactionStatusDto.REFUND_REQUESTED, TransactionStatusDto.REFUNDED)

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
@@ -1061,6 +1061,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionUserReceiptRepository, times(0)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
       verify(userReceiptMailBuilder, times(1)).buildNotificationEmailRequestDto(baseTransaction)
+      verify(deadLetterQueueAsyncClient, times(1))
+        .sendMessageWithResponse(any<BinaryData>(), any(), anyOrNull())
       assertEquals(
         String(
           jsonSerializerV2.serializeToBytes(

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
@@ -791,7 +791,8 @@ class TransactionsRefundEventsConsumerTests {
         UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
     verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
-
+    verify(deadLetterQueueAsyncClient, times(1))
+      .sendMessageWithResponse(any<BinaryData>(), any(), any())
     val storedEvent = refundEventStoreCaptor.value
     assertEquals(
       TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT,
@@ -871,6 +872,8 @@ class TransactionsRefundEventsConsumerTests {
           UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      verify(deadLetterQueueAsyncClient, times(1))
+        .sendMessageWithResponse(any<BinaryData>(), any(), any())
       assertEquals(
         String(
           jsonSerializerV2.serializeToBytes(
@@ -1136,6 +1139,8 @@ class TransactionsRefundEventsConsumerTests {
           pspId = expectedPspId)
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      verify(deadLetterQueueAsyncClient, times(1))
+        .sendMessageWithResponse(any<BinaryData>(), any(), any())
       assertEquals(
         String(
           jsonSerializerV2.serializeToBytes(

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.eventdispatcher.queues.v2
 
+import com.azure.core.util.BinaryData
 import com.azure.spring.messaging.checkpoint.Checkpointer
 import com.azure.storage.queue.QueueAsyncClient
 import io.vavr.control.Either
@@ -25,9 +26,11 @@ import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsViewReposito
 import it.pagopa.ecommerce.eventdispatcher.services.RefundService
 import it.pagopa.ecommerce.eventdispatcher.services.eventretry.v2.RefundRetryService
 import it.pagopa.ecommerce.eventdispatcher.utils.DEAD_LETTER_QUEUE_TTL_SECONDS
+import it.pagopa.ecommerce.eventdispatcher.utils.queueSuccessfulResponse
 import it.pagopa.generated.ecommerce.gateway.v1.dto.VposDeleteResponseDto
 import it.pagopa.generated.ecommerce.gateway.v1.dto.XPayRefundResponse200Dto
 import java.math.BigDecimal
+import java.nio.charset.StandardCharsets
 import java.time.ZonedDateTime
 import java.util.*
 import java.util.stream.Stream
@@ -73,6 +76,8 @@ class TransactionsRefundEventsConsumerTests {
   private lateinit var refundEventStoreCaptor:
     ArgumentCaptor<TransactionEvent<TransactionRefundedData>>
 
+  @Captor private lateinit var queueArgumentCaptor: ArgumentCaptor<BinaryData>
+
   private val transactionsViewRepository: TransactionsViewRepository = mock()
 
   private val deadLetterQueueAsyncClient: QueueAsyncClient = mock()
@@ -90,6 +95,8 @@ class TransactionsRefundEventsConsumerTests {
       deadLetterTTLSeconds = DEAD_LETTER_QUEUE_TTL_SECONDS,
       tracingUtils = tracingUtils,
       strictSerializerProviderV2 = strictJsonSerializerProviderV2)
+
+  private val jsonSerializerV2 = strictJsonSerializerProviderV2.createInstance()
 
   companion object {
     @JvmStatic
@@ -763,6 +770,10 @@ class TransactionsRefundEventsConsumerTests {
       .willReturn(
         Mono.just(transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now())))
 
+    given(
+        deadLetterQueueAsyncClient.sendMessageWithResponse(
+          queueArgumentCaptor.capture(), any(), anyOrNull()))
+      .willReturn(queueSuccessfulResponse())
     /* test */
 
     StepVerifier.create(
@@ -786,6 +797,12 @@ class TransactionsRefundEventsConsumerTests {
       TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT,
       TransactionEventCode.valueOf(storedEvent.eventCode))
     assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
+    assertEquals(
+      String(
+        jsonSerializerV2.serializeToBytes(
+          QueueEvent(refundRequestedEvent as TransactionRefundRequestedEvent, MOCK_TRACING_INFO)),
+        StandardCharsets.UTF_8),
+      String(queueArgumentCaptor.value.toBytes(), StandardCharsets.UTF_8))
   }
 
   @Test
@@ -832,7 +849,10 @@ class TransactionsRefundEventsConsumerTests {
         .willReturn(
           Mono.just(
             transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now())))
-
+      given(
+          deadLetterQueueAsyncClient.sendMessageWithResponse(
+            queueArgumentCaptor.capture(), any(), anyOrNull()))
+        .willReturn(queueSuccessfulResponse())
       /* test */
 
       StepVerifier.create(
@@ -851,6 +871,12 @@ class TransactionsRefundEventsConsumerTests {
           UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      assertEquals(
+        String(
+          jsonSerializerV2.serializeToBytes(
+            QueueEvent(refundRequestedEvent as TransactionRefundRequestedEvent, MOCK_TRACING_INFO)),
+          StandardCharsets.UTF_8),
+        String(queueArgumentCaptor.value.toBytes(), StandardCharsets.UTF_8))
 
       val storedEvent = refundEventStoreCaptor.value
       assertEquals(
@@ -1073,7 +1099,10 @@ class TransactionsRefundEventsConsumerTests {
         .willReturn(
           Mono.just(
             transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now())))
-
+      given(
+          deadLetterQueueAsyncClient.sendMessageWithResponse(
+            queueArgumentCaptor.capture(), any(), anyOrNull()))
+        .willReturn(queueSuccessfulResponse())
       /* test */
 
       StepVerifier.create(
@@ -1107,6 +1136,12 @@ class TransactionsRefundEventsConsumerTests {
           pspId = expectedPspId)
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      assertEquals(
+        String(
+          jsonSerializerV2.serializeToBytes(
+            QueueEvent(refundRequestedEvent as TransactionRefundRequestedEvent, MOCK_TRACING_INFO)),
+          StandardCharsets.UTF_8),
+        String(queueArgumentCaptor.value.toBytes(), StandardCharsets.UTF_8))
 
       val storedEvent = refundEventStoreCaptor.value
       assertEquals(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to write to event dispatcher`dead-letter-queue` for the following cases:

1.  no attempt left for retry sending email to user
2. refund process is interrupted due to an error response for which no more attempts have to be performed, such as an 4xx error or an inconsistent state (for PGS only)

<!--- Describe your changes in detail -->

#### Motivation and Context
In case there are no attempts left for retry sending an email or perform a refund the retry event have to be written to dead-letter-queue in order to trace this error
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local test using eCommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.