### PR TITLE
feat: CHK-224 add refundable manual check for authorization completed transaction

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumer.kt
@@ -158,7 +158,8 @@ class TransactionExpirationQueueConsumer(
                 DeadLetterTracedQueueAsyncClient.ErrorContext(
                   transactionId = TransactionId(event.transactionId),
                   transactionEventCode = event.eventCode,
-                  errorCategory = DeadLetterTracedQueueAsyncClient.ErrorCategory.PROCESSING_ERROR),
+                  errorCategory =
+                    DeadLetterTracedQueueAsyncClient.ErrorCategory.REFUND_MANUAL_CHECK_REQUIRED),
               )
               .thenReturn(true)
           }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumer.kt
@@ -139,10 +139,30 @@ class TransactionExpirationQueueConsumer(
           }
         }
         .filter {
+          val refundableCheckRequired = isRefundableCheckRequired(it)
           val refundable = isTransactionRefundable(it)
+          val refundableWithoutCheck = refundable && !refundableCheckRequired
           logger.info(
-            "Transaction ${it.transactionId.value()} in status ${it.status}, refundable: $refundable")
-          refundable
+            "Transaction ${it.transactionId.value()} in status ${it.status}, refundable : $refundable, without check : $refundableWithoutCheck")
+          if (refundableCheckRequired) {
+            val tracingInfo = queueEvent.second
+            val binaryData =
+              if (tracingInfo == null) {
+                BinaryData.fromObject(event)
+              } else {
+                BinaryData.fromObject(QueueEvent(event, tracingInfo))
+              }
+            deadLetterTracedQueueAsyncClient
+              .sendAndTraceDeadLetterQueueEvent(
+                binaryData,
+                DeadLetterTracedQueueAsyncClient.ErrorContext(
+                  transactionId = TransactionId(event.transactionId),
+                  transactionEventCode = event.eventCode,
+                  errorCategory = DeadLetterTracedQueueAsyncClient.ErrorCategory.PROCESSING_ERROR),
+              )
+              .thenReturn(true)
+          }
+          refundableWithoutCheck
         }
         .flatMap {
           updateTransactionToRefundRequested(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/common.kt
@@ -316,6 +316,10 @@ fun isTransactionRefundable(tx: BaseTransaction): Boolean {
   return isTransactionRefundable
 }
 
+fun isRefundableCheckRequired(tx: BaseTransaction): Boolean {
+  return tx.status == TransactionStatusDto.AUTHORIZATION_COMPLETED && !wasAuthorizationDenied(tx)
+}
+
 fun wasSendPaymentResultOutcomeKO(tx: BaseTransaction): Boolean =
   when (tx) {
     is BaseTransactionWithRequestedUserReceipt ->

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/DeadLetterTracedQueueAsyncClient.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/DeadLetterTracedQueueAsyncClient.kt
@@ -95,7 +95,10 @@ class DeadLetterTracedQueueAsyncClient(
     EVENT_PARSING_ERROR,
 
     /** Event processing error caused by generic processing error */
-    PROCESSING_ERROR
+    PROCESSING_ERROR,
+
+    /** Event processing error caused by manual refundable check required */
+    REFUND_MANUAL_CHECK_REQUIRED
   }
 
   /**

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumerTests.kt
@@ -2375,7 +2375,8 @@ class TransactionExpirationQueueConsumerTests {
             DeadLetterTracedQueueAsyncClient.ErrorContext(
               transactionId = TransactionId(TRANSACTION_ID),
               transactionEventCode = TransactionEventCode.TRANSACTION_ACTIVATED_EVENT.toString(),
-              errorCategory = DeadLetterTracedQueueAsyncClient.ErrorCategory.PROCESSING_ERROR)))
+              errorCategory =
+                DeadLetterTracedQueueAsyncClient.ErrorCategory.REFUND_MANUAL_CHECK_REQUIRED)))
       /*
        * check view update statuses and events stored into event store
        */

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionExpirationQueueConsumerTests.kt
@@ -2300,7 +2300,7 @@ class TransactionExpirationQueueConsumerTests {
     }
 
   @Test
-  fun `messageReceiver should perform refund for a transaction in AUTHORIZATION_COMPLETED status with auth outcome OK`() =
+  fun `messageReceiver should not perform refund for a transaction in AUTHORIZATION_COMPLETED status with auth outcome OK`() =
     runTest {
       val activatedEvent = transactionActivateEvent()
       val authorizationRequestedEvent = transactionAuthorizationRequestedEvent()
@@ -2342,8 +2342,10 @@ class TransactionExpirationQueueConsumerTests {
       given(transactionsViewRepository.save(transactionViewRepositoryCaptor.capture())).willAnswer {
         Mono.just(it.arguments[0])
       }
-      given(paymentGatewayClient.requestVPosRefund(any()))
-        .willReturn(Mono.just(gatewayClientResponse))
+      given(
+          deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
+            capture(binaryDataCaptor), any()))
+        .willReturn(mono {})
 
       Hooks.onOperatorDebug()
       /* test */
@@ -2360,21 +2362,24 @@ class TransactionExpirationQueueConsumerTests {
       /* Asserts */
       verify(checkpointer, times(1)).success()
       verify(transactionsExpiredEventStoreRepository, times(1)).save(any())
-      verify(paymentGatewayClient, times(1)).requestVPosRefund(any())
-      verify(transactionsRefundedEventStoreRepository, times(2)).save(any())
-      verify(transactionsViewRepository, times(3)).save(any())
+      verify(transactionsViewRepository, times(1)).save(any())
+      verify(deadLetterTracedQueueAsyncClient, times(1))
+        .sendAndTraceDeadLetterQueueEvent(
+          argThat<BinaryData> {
+            TransactionEventCode.valueOf(
+              this.toObject(object : TypeReference<QueueEvent<TransactionActivatedEvent>>() {})
+                .event
+                .eventCode) == TransactionEventCode.TRANSACTION_ACTIVATED_EVENT
+          },
+          eq(
+            DeadLetterTracedQueueAsyncClient.ErrorContext(
+              transactionId = TransactionId(TRANSACTION_ID),
+              transactionEventCode = TransactionEventCode.TRANSACTION_ACTIVATED_EVENT.toString(),
+              errorCategory = DeadLetterTracedQueueAsyncClient.ErrorCategory.PROCESSING_ERROR)))
       /*
        * check view update statuses and events stored into event store
        */
-      val expectedRefundEventStatuses =
-        listOf(
-          TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT,
-          TransactionEventCode.TRANSACTION_REFUNDED_EVENT)
-      val viewExpectedStatuses =
-        listOf(
-          TransactionStatusDto.EXPIRED,
-          TransactionStatusDto.REFUND_REQUESTED,
-          TransactionStatusDto.REFUNDED)
+      val viewExpectedStatuses = listOf(TransactionStatusDto.EXPIRED)
       viewExpectedStatuses.forEachIndexed { idx, expectedStatus ->
         assertEquals(
           expectedStatus,
@@ -2382,12 +2387,6 @@ class TransactionExpirationQueueConsumerTests {
           "Unexpected view status on idx: $idx")
       }
 
-      expectedRefundEventStatuses.forEachIndexed { idx, expectedStatus ->
-        assertEquals(
-          expectedStatus,
-          TransactionEventCode.valueOf(transactionRefundEventStoreCaptor.allValues[idx].eventCode),
-          "Unexpected event code on idx: $idx")
-      }
       val expiredEvent = transactionExpiredEventStoreCaptor.value
       assertEquals(
         TransactionEventCode.TRANSACTION_EXPIRED_EVENT,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- disable refund for expired transaction in authorization completed status

#### Motivation and Context

The goal of this PR is to add a check to disable refund for expired transaction in authorization completed event and send event in deadletter.
This step is required waiting async refactoring for `PATH auth-requests`,  currently both the  authorization outcome update and the closepayment are perform in this API, and if it has a response time greater than 10 sec an inconsistent status may occur, i.e. the outcome of the authorization is updated but not the closepayment attempt. So, these cases must be managed in the deadletter.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.