### PR TITLE
fix: write event to dead letter queue

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/common.kt
@@ -316,9 +316,14 @@ fun isTransactionRefundable(tx: BaseTransaction): Boolean {
   return isTransactionRefundable
 }
 
-fun isRefundableCheckRequired(tx: BaseTransaction): Boolean {
-  return tx.status == TransactionStatusDto.AUTHORIZATION_COMPLETED && !wasAuthorizationDenied(tx)
-}
+fun isRefundableCheckRequired(tx: BaseTransaction): Boolean =
+  when (tx) {
+    is BaseTransactionExpired ->
+      tx.transactionExpiredData.statusBeforeExpiration ==
+        TransactionStatusDto.AUTHORIZATION_COMPLETED &&
+        isRefundableCheckRequired(tx.transactionAtPreviousState)
+    else -> tx.status == TransactionStatusDto.AUTHORIZATION_COMPLETED && !wasAuthorizationDenied(tx)
+  }
 
 fun wasSendPaymentResultOutcomeKO(tx: BaseTransaction): Boolean =
   when (tx) {

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -609,3 +609,12 @@ fun <T> timeLeftForSendPaymentResult(
     Mono.empty()
   }
 }
+
+fun isRefundableCheckRequired(tx: BaseTransaction): Boolean =
+  when (tx) {
+    is BaseTransactionExpired ->
+      tx.transactionExpiredData.statusBeforeExpiration ==
+        TransactionStatusDto.AUTHORIZATION_COMPLETED &&
+        isRefundableCheckRequired(tx.transactionAtPreviousState)
+    else -> tx.status == TransactionStatusDto.AUTHORIZATION_COMPLETED && !wasAuthorizationDenied(tx)
+  }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionExpirationQueueConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionExpirationQueueConsumerTests.kt
@@ -2330,6 +2330,10 @@ class TransactionExpirationQueueConsumerTests {
           transactionsRefundedEventStoreRepository.save(
             transactionRefundEventStoreCaptor.capture()))
         .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
+            capture(binaryDataCaptor), any()))
+        .willReturn(mono {})
       given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
         .willReturnConsecutively(
           listOf(
@@ -2358,22 +2362,30 @@ class TransactionExpirationQueueConsumerTests {
 
       /* Asserts */
       verify(checkpointer, times(1)).success()
+      verify(deadLetterTracedQueueAsyncClient, times(1))
+        .sendAndTraceDeadLetterQueueEvent(
+          argThat<BinaryData> {
+            TransactionEventCode.valueOf(
+              this.toObject(
+                  object : TypeReference<QueueEvent<TransactionActivatedEvent>>() {},
+                  jsonSerializerV2)
+                .event
+                .eventCode) == TransactionEventCode.TRANSACTION_ACTIVATED_EVENT
+          },
+          eq(
+            DeadLetterTracedQueueAsyncClient.ErrorContext(
+              transactionId = TransactionId(TRANSACTION_ID),
+              transactionEventCode = TransactionEventCode.TRANSACTION_ACTIVATED_EVENT.toString(),
+              errorCategory =
+                DeadLetterTracedQueueAsyncClient.ErrorCategory.REFUND_MANUAL_CHECK_REQUIRED)))
       verify(transactionsExpiredEventStoreRepository, times(1)).save(any())
-      verify(paymentGatewayClient, times(1)).requestVPosRefund(any())
-      verify(transactionsRefundedEventStoreRepository, times(2)).save(any())
-      verify(transactionsViewRepository, times(3)).save(any())
+      verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+      verify(transactionsRefundedEventStoreRepository, times(0)).save(any())
+      verify(transactionsViewRepository, times(1)).save(any())
       /*
        * check view update statuses and events stored into event store
        */
-      val expectedRefundEventStatuses =
-        listOf(
-          TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT,
-          TransactionEventCode.TRANSACTION_REFUNDED_EVENT)
-      val viewExpectedStatuses =
-        listOf(
-          TransactionStatusDto.EXPIRED,
-          TransactionStatusDto.REFUND_REQUESTED,
-          TransactionStatusDto.REFUNDED)
+      val viewExpectedStatuses = listOf(TransactionStatusDto.EXPIRED)
       viewExpectedStatuses.forEachIndexed { idx, expectedStatus ->
         assertEquals(
           expectedStatus,
@@ -2381,12 +2393,6 @@ class TransactionExpirationQueueConsumerTests {
           "Unexpected view status on idx: $idx")
       }
 
-      expectedRefundEventStatuses.forEachIndexed { idx, expectedStatus ->
-        assertEquals(
-          expectedStatus,
-          TransactionEventCode.valueOf(transactionRefundEventStoreCaptor.allValues[idx].eventCode),
-          "Unexpected event code on idx: $idx")
-      }
       val expiredEvent = transactionExpiredEventStoreCaptor.value
       assertEquals(
         TransactionEventCode.TRANSACTION_EXPIRED_EVENT,
@@ -2442,7 +2448,10 @@ class TransactionExpirationQueueConsumerTests {
       }
       given(paymentGatewayClient.requestVPosRefund(any()))
         .willReturn(Mono.just(gatewayClientResponse))
-
+      given(
+          deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
+            capture(binaryDataCaptor), any()))
+        .willReturn(mono {})
       Hooks.onOperatorDebug()
       /* test */
       StepVerifier.create(
@@ -2456,32 +2465,26 @@ class TransactionExpirationQueueConsumerTests {
 
       /* Asserts */
       verify(checkpointer, times(1)).success()
+      verify(deadLetterTracedQueueAsyncClient, times(1))
+        .sendAndTraceDeadLetterQueueEvent(
+          argThat<BinaryData> {
+            TransactionEventCode.valueOf(
+              this.toObject(
+                  object : TypeReference<QueueEvent<TransactionActivatedEvent>>() {},
+                  jsonSerializerV2)
+                .event
+                .eventCode) == TransactionEventCode.TRANSACTION_ACTIVATED_EVENT
+          },
+          eq(
+            DeadLetterTracedQueueAsyncClient.ErrorContext(
+              transactionId = TransactionId(TRANSACTION_ID),
+              transactionEventCode = TransactionEventCode.TRANSACTION_ACTIVATED_EVENT.toString(),
+              errorCategory =
+                DeadLetterTracedQueueAsyncClient.ErrorCategory.REFUND_MANUAL_CHECK_REQUIRED)))
       verify(transactionsExpiredEventStoreRepository, times(0)).save(any())
-      verify(paymentGatewayClient, times(1)).requestVPosRefund(any())
-      verify(transactionsRefundedEventStoreRepository, times(2)).save(any())
-      verify(transactionsViewRepository, times(2)).save(any())
-      /*
-       * check view update statuses and events stored into event store
-       */
-      val expectedRefundEventStatuses =
-        listOf(
-          TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT,
-          TransactionEventCode.TRANSACTION_REFUNDED_EVENT)
-      val viewExpectedStatuses =
-        listOf(TransactionStatusDto.REFUND_REQUESTED, TransactionStatusDto.REFUNDED)
-      viewExpectedStatuses.forEachIndexed { idx, expectedStatus ->
-        assertEquals(
-          expectedStatus,
-          transactionViewRepositoryCaptor.allValues[idx].status,
-          "Unexpected view status on idx: $idx")
-      }
-
-      expectedRefundEventStatuses.forEachIndexed { idx, expectedStatus ->
-        assertEquals(
-          expectedStatus,
-          TransactionEventCode.valueOf(transactionRefundEventStoreCaptor.allValues[idx].eventCode),
-          "Unexpected event code on idx: $idx")
-      }
+      verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+      verify(transactionsRefundedEventStoreRepository, times(0)).save(any())
+      verify(transactionsViewRepository, times(0)).save(any())
     }
 
   @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Fix event writing to dead letter queue for transactions stuck in AUTHORIZATION_COMPLETED status.
Logic was written into a filter method and dead letter event writing event was never subscribed.
The fix consisted in change filter to filterWhen method plays a mono that produces a boolean for make filter check
2. Include also transactions stuck in AUTHORIZATION_COMPLETED event that have been expired by transactions-scheduler-service 
3. Ported filter logic to v2 expiration event handler

<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to properly write event to dead letter queue in case of refund to be processed manually after a check against Nodo position
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local tests using eCommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.