### PR TITLE
fix(refund): [CHK-2264] - perform retries when PGS transaction status is CREATED

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/common.kt
@@ -242,8 +242,7 @@ fun handleVposRefundResponse(
       updateTransactionToRefunded(
         transaction, transactionsEventStoreRepository, transactionsViewRepository)
     }
-    StatusEnum.DENIED,
-    StatusEnum.CREATED -> {
+    StatusEnum.DENIED -> {
       logger.info(
         "Refund for transaction with id: [${transaction.transactionId.value()}] denied with pgs response status: [${refundResponse.status}]! No more attempts will be performed")
       updateTransactionToRefundError(
@@ -272,8 +271,7 @@ fun handleXpayRefundResponse(
       updateTransactionToRefunded(
         transaction, transactionsEventStoreRepository, transactionsViewRepository)
     }
-    XPayRefundResponse200Dto.StatusEnum.DENIED,
-    XPayRefundResponse200Dto.StatusEnum.CREATED -> {
+    XPayRefundResponse200Dto.StatusEnum.DENIED -> {
       logger.info(
         "Refund for transaction with id: [${transaction.transactionId.value()}] denied with pgs response status: [${refundResponse.status}]!! No more attempts will be performed")
       updateTransactionToRefundError(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -270,8 +270,7 @@ fun handleVposRefundResponse(
       updateTransactionToRefunded(
         transaction, transactionsEventStoreRepository, transactionsViewRepository)
     }
-    StatusEnum.DENIED,
-    StatusEnum.CREATED -> {
+    StatusEnum.DENIED -> {
       logger.info(
         "Refund for transaction with id: [${transaction.transactionId.value()}] denied with pgs response status: [${refundResponse.status}]! No more attempts will be performed")
       updateTransactionToRefundError(
@@ -300,8 +299,7 @@ fun handleXpayRefundResponse(
       updateTransactionToRefunded(
         transaction, transactionsEventStoreRepository, transactionsViewRepository)
     }
-    XPayRefundResponse200Dto.StatusEnum.DENIED,
-    XPayRefundResponse200Dto.StatusEnum.CREATED -> {
+    XPayRefundResponse200Dto.StatusEnum.DENIED -> {
       logger.info(
         "Refund for transaction with id: [${transaction.transactionId.value()}] denied with pgs response status: [${refundResponse.status}]!! No more attempts will be performed")
       updateTransactionToRefundError(

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionsRefundEventsConsumerTests.kt
@@ -580,7 +580,7 @@ class TransactionsRefundEventsConsumerTests {
   @MethodSource("vposStatusesToEnqueueRetryEventMapping")
   fun `consumer should handle response from PGS status correctly (vpos)`(
     pgsStatus: VposDeleteResponseDto.StatusEnum,
-    shouldWriteErrorEvent: Boolean,
+    shouldWriteRetryEvent: Boolean,
     expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
@@ -643,7 +643,7 @@ class TransactionsRefundEventsConsumerTests {
     verify(
         refundRetryService,
         times(
-          if (shouldWriteErrorEvent) {
+          if (shouldWriteRetryEvent) {
             1
           } else {
             0
@@ -659,7 +659,7 @@ class TransactionsRefundEventsConsumerTests {
   @MethodSource("xpayStatusesToEnqueueRetryEventMapping")
   fun `consumer should handle response from PGS status correctly (xpay)`(
     pgsStatus: XPayRefundResponse200Dto.StatusEnum,
-    shouldWriteErrorEvent: Boolean,
+    shouldWriteRetryEvent: Boolean,
     expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
@@ -723,7 +723,7 @@ class TransactionsRefundEventsConsumerTests {
     verify(
         refundRetryService,
         times(
-          if (shouldWriteErrorEvent) {
+          if (shouldWriteRetryEvent) {
             1
           } else {
             0

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionsRefundEventsConsumerTests.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
@@ -76,13 +77,46 @@ class TransactionsRefundEventsConsumerTests {
 
   companion object {
     @JvmStatic
-    private fun vposStatusToRefundError() =
-      Stream.of(VposDeleteResponseDto.StatusEnum.DENIED, VposDeleteResponseDto.StatusEnum.CREATED)
+    private fun vposStatusesToEnqueueRetryEventMapping() =
+      Stream.of(
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.AUTHORIZED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.CREATED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.CANCELLED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT),
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.DENIED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+      )
 
     @JvmStatic
-    private fun xpayStatusToRefundError() =
+    private fun xpayStatusesToEnqueueRetryEventMapping() =
       Stream.of(
-        XPayRefundResponse200Dto.StatusEnum.DENIED, XPayRefundResponse200Dto.StatusEnum.CREATED)
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.AUTHORIZED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.CREATED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.CANCELLED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT),
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.DENIED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+      )
   }
 
   @Test
@@ -543,9 +577,11 @@ class TransactionsRefundEventsConsumerTests {
   }
 
   @ParameterizedTest
-  @MethodSource("vposStatusToRefundError")
-  fun `consumer does not enqueue refund retry event for DENIED or CREATED response from PGS (vpos)`(
-    errorStatus: VposDeleteResponseDto.StatusEnum
+  @MethodSource("vposStatusesToEnqueueRetryEventMapping")
+  fun `consumer should handle response from PGS status correctly (vpos)`(
+    pgsStatus: VposDeleteResponseDto.StatusEnum,
+    shouldWriteErrorEvent: Boolean,
+    expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
     val authorizationRequestEvent =
@@ -559,7 +595,7 @@ class TransactionsRefundEventsConsumerTests {
         TRANSACTION_ID, TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
         as TransactionEvent<Any>
 
-    val gatewayClientResponse = VposDeleteResponseDto().apply { status = errorStatus }
+    val gatewayClientResponse = VposDeleteResponseDto().apply { status = pgsStatus }
 
     val events =
       listOf(
@@ -604,19 +640,27 @@ class TransactionsRefundEventsConsumerTests {
       .requestVPosRefund(
         UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+    verify(
+        refundRetryService,
+        times(
+          if (shouldWriteErrorEvent) {
+            1
+          } else {
+            0
+          }))
+      .enqueueRetryEvent(any(), any(), any())
 
     val storedEvent = refundEventStoreCaptor.value
-    assertEquals(
-      TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT,
-      TransactionEventCode.valueOf(storedEvent.eventCode))
+    assertEquals(expectedWrittenEventStatus, TransactionEventCode.valueOf(storedEvent.eventCode))
     assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
   }
 
   @ParameterizedTest
-  @MethodSource("xpayStatusToRefundError")
-  fun `consumer does not enqueue refund retry event for DENIED or CREATED response from PGS (xpay)`(
-    errorStatus: XPayRefundResponse200Dto.StatusEnum
+  @MethodSource("xpayStatusesToEnqueueRetryEventMapping")
+  fun `consumer should handle response from PGS status correctly (xpay)`(
+    pgsStatus: XPayRefundResponse200Dto.StatusEnum,
+    shouldWriteErrorEvent: Boolean,
+    expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
     val authorizationRequestEvent =
@@ -632,7 +676,7 @@ class TransactionsRefundEventsConsumerTests {
         TRANSACTION_ID, TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
         as TransactionEvent<Any>
 
-    val gatewayClientResponse = XPayRefundResponse200Dto().apply { status = errorStatus }
+    val gatewayClientResponse = XPayRefundResponse200Dto().apply { status = pgsStatus }
 
     val events =
       listOf(
@@ -676,12 +720,18 @@ class TransactionsRefundEventsConsumerTests {
       .requestXPayRefund(
         UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+    verify(
+        refundRetryService,
+        times(
+          if (shouldWriteErrorEvent) {
+            1
+          } else {
+            0
+          }))
+      .enqueueRetryEvent(any(), any(), any())
 
     val storedEvent = refundEventStoreCaptor.value
-    assertEquals(
-      TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT,
-      TransactionEventCode.valueOf(storedEvent.eventCode))
+    assertEquals(expectedWrittenEventStatus, TransactionEventCode.valueOf(storedEvent.eventCode))
     assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
   }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
@@ -614,7 +614,7 @@ class TransactionsRefundEventsConsumerTests {
   @MethodSource("vposStatusesToEnqueueRetryEventMapping")
   fun `consumer should handle response from PGS status correctly (vpos)`(
     pgsStatus: VposDeleteResponseDto.StatusEnum,
-    shouldWriteErrorEvent: Boolean,
+    shouldWriteRetryEvent: Boolean,
     expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
@@ -679,7 +679,7 @@ class TransactionsRefundEventsConsumerTests {
     verify(
         refundRetryService,
         times(
-          if (shouldWriteErrorEvent) {
+          if (shouldWriteRetryEvent) {
             1
           } else {
             0
@@ -695,7 +695,7 @@ class TransactionsRefundEventsConsumerTests {
   @MethodSource("xpayStatusesToEnqueueRetryEventMapping")
   fun `consumer should handle response from PGS status correctly (xpay)`(
     pgsStatus: XPayRefundResponse200Dto.StatusEnum,
-    shouldWriteErrorEvent: Boolean,
+    shouldWriteRetryEvent: Boolean,
     expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
@@ -761,7 +761,7 @@ class TransactionsRefundEventsConsumerTests {
     verify(
         refundRetryService,
         times(
-          if (shouldWriteErrorEvent) {
+          if (shouldWriteRetryEvent) {
             1
           } else {
             0

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
@@ -97,13 +98,46 @@ class TransactionsRefundEventsConsumerTests {
 
   companion object {
     @JvmStatic
-    private fun vposStatusToRefundError() =
-      Stream.of(VposDeleteResponseDto.StatusEnum.DENIED, VposDeleteResponseDto.StatusEnum.CREATED)
+    private fun vposStatusesToEnqueueRetryEventMapping() =
+      Stream.of(
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.AUTHORIZED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.CREATED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.CANCELLED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT),
+        Arguments.of(
+          VposDeleteResponseDto.StatusEnum.DENIED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+      )
 
     @JvmStatic
-    private fun xpayStatusToRefundError() =
+    private fun xpayStatusesToEnqueueRetryEventMapping() =
       Stream.of(
-        XPayRefundResponse200Dto.StatusEnum.DENIED, XPayRefundResponse200Dto.StatusEnum.CREATED)
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.AUTHORIZED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.CREATED,
+          true,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.CANCELLED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT),
+        Arguments.of(
+          XPayRefundResponse200Dto.StatusEnum.DENIED,
+          false,
+          TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT),
+      )
   }
 
   @Test
@@ -577,9 +611,11 @@ class TransactionsRefundEventsConsumerTests {
   }
 
   @ParameterizedTest
-  @MethodSource("vposStatusToRefundError")
-  fun `consumer does not enqueue refund retry event for DENIED or CREATED response from PGS (vpos)`(
-    errorStatus: VposDeleteResponseDto.StatusEnum
+  @MethodSource("vposStatusesToEnqueueRetryEventMapping")
+  fun `consumer should handle response from PGS status correctly (vpos)`(
+    pgsStatus: VposDeleteResponseDto.StatusEnum,
+    shouldWriteErrorEvent: Boolean,
+    expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
     val authorizationRequestEvent =
@@ -595,7 +631,7 @@ class TransactionsRefundEventsConsumerTests {
         TRANSACTION_ID, TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
         as TransactionEvent<Any>
 
-    val gatewayClientResponse = VposDeleteResponseDto().apply { status = errorStatus }
+    val gatewayClientResponse = VposDeleteResponseDto().apply { status = pgsStatus }
 
     val events =
       listOf(
@@ -640,19 +676,27 @@ class TransactionsRefundEventsConsumerTests {
       .requestVPosRefund(
         UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+    verify(
+        refundRetryService,
+        times(
+          if (shouldWriteErrorEvent) {
+            1
+          } else {
+            0
+          }))
+      .enqueueRetryEvent(any(), any(), any())
 
     val storedEvent = refundEventStoreCaptor.value
-    assertEquals(
-      TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT,
-      TransactionEventCode.valueOf(storedEvent.eventCode))
+    assertEquals(expectedWrittenEventStatus, TransactionEventCode.valueOf(storedEvent.eventCode))
     assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
   }
 
   @ParameterizedTest
-  @MethodSource("xpayStatusToRefundError")
-  fun `consumer does not enqueue refund retry event for DENIED or CREATED response from PGS (xpay)`(
-    errorStatus: XPayRefundResponse200Dto.StatusEnum
+  @MethodSource("xpayStatusesToEnqueueRetryEventMapping")
+  fun `consumer should handle response from PGS status correctly (xpay)`(
+    pgsStatus: XPayRefundResponse200Dto.StatusEnum,
+    shouldWriteErrorEvent: Boolean,
+    expectedWrittenEventStatus: TransactionEventCode
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
     val authorizationRequestEvent =
@@ -670,7 +714,7 @@ class TransactionsRefundEventsConsumerTests {
         TRANSACTION_ID, TransactionRefundedData(TransactionStatusDto.REFUND_REQUESTED))
         as TransactionEvent<Any>
 
-    val gatewayClientResponse = XPayRefundResponse200Dto().apply { status = errorStatus }
+    val gatewayClientResponse = XPayRefundResponse200Dto().apply { status = pgsStatus }
 
     val events =
       listOf(
@@ -714,12 +758,18 @@ class TransactionsRefundEventsConsumerTests {
       .requestXPayRefund(
         UUID.fromString(transaction.transactionAuthorizationRequestData.authorizationRequestId))
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+    verify(
+        refundRetryService,
+        times(
+          if (shouldWriteErrorEvent) {
+            1
+          } else {
+            0
+          }))
+      .enqueueRetryEvent(any(), any(), any())
 
     val storedEvent = refundEventStoreCaptor.value
-    assertEquals(
-      TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT,
-      TransactionEventCode.valueOf(storedEvent.eventCode))
+    assertEquals(expectedWrittenEventStatus, TransactionEventCode.valueOf(storedEvent.eventCode))
     assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Modified PGS status handling logic for CREATED case: this case should be handled as a non final status and make service perform other refund retry attempts
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification will cover all that cases when refund call is made just before the authorization process is completed PGS side, reading a CREATED status that will be valid until authorization process is completed.
Skipping those refund retry attempts lead to manual refund to be process for those transactions (eCommerce wants to refund the transaction but cannot succeed (CREATED status received) and did not perform any other attempts.
All those manual refund can be simply avoid making the system perform more attempts when the PGS returned status is CREATED.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.