### PR TITLE
[CHK-2334] fix(deps): mark `netty-resolver-dns-native-macos` dependency for test only as it causes memleak in prod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@
 			<artifactId>netty-resolver-dns-native-macos</artifactId>
 			<version>4.1.82.Final</version>
 			<classifier>osx-aarch_64</classifier>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * mark netty-resolver-dns-native-macos dependency for test only as it causes memleak in prod

#### Motivation and Context
The dependency was needed for macOS on ARM arch and was included unconditionally, but it causes a memory leak of non-heap memory in Linux hosts.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Deployment in dev environment and monitoring on memory.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.