### PR TITLE
[CHK-2444] Correlation id into npg refund request

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -3,6 +3,7 @@ package it.pagopa.ecommerce.eventdispatcher.queues.v2
 import com.azure.core.util.BinaryData
 import com.azure.spring.messaging.checkpoint.Checkpointer
 import it.pagopa.ecommerce.commons.documents.v2.*
+import it.pagopa.ecommerce.commons.documents.v2.activation.NpgTransactionGatewayActivationData
 import it.pagopa.ecommerce.commons.documents.v2.authorization.NpgTransactionGatewayAuthorizationData
 import it.pagopa.ecommerce.commons.documents.v2.authorization.PgsTransactionGatewayAuthorizationData
 import it.pagopa.ecommerce.commons.documents.v2.authorization.RedirectTransactionGatewayAuthorizationData
@@ -195,7 +196,10 @@ fun refundTransaction(
                   transaction.transactionId.uuid,
                   BigDecimal(transaction.transactionAuthorizationRequestData.amount)
                     .add(BigDecimal(transaction.transactionAuthorizationRequestData.fee)),
-                  transaction.transactionAuthorizationRequestData.pspId)
+                  transaction.transactionAuthorizationRequestData.pspId,
+                  (transaction.transactionActivatedData.transactionGatewayActivationData
+                      as NpgTransactionGatewayActivationData)
+                    .correlationId)
                 .map { refundResponse -> Pair(refundResponse, transaction) }
             }
         }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/RefundService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/RefundService.kt
@@ -26,14 +26,15 @@ class RefundService(
     operationId: String,
     idempotenceKey: UUID,
     amount: BigDecimal,
-    pspId: String
+    pspId: String,
+    correlationId: String
   ): Mono<RefundResponseDto> {
     return npgCardsPspApiKey[pspId].fold(
       { ex -> Mono.error(ex) },
       { apiKey ->
         npgClient
           .refundPayment(
-            UUID.randomUUID(),
+            UUID.fromString(correlationId),
             operationId,
             idempotenceKey,
             amount,

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/RefundServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/RefundServiceTests.kt
@@ -90,6 +90,7 @@ class RefundServiceTests {
   fun requestRefund_200_npg() {
     val operationId = "operationID"
     val idempotenceKey = UUID.randomUUID()
+    val correlationId = UUID.randomUUID().toString()
     val amount = BigDecimal.valueOf(1000)
     val pspId = "pspId1"
     // Precondition
@@ -109,7 +110,8 @@ class RefundServiceTests {
         .setHeader("Content-type", "application/json")
         .setResponseCode(200))
     // Test
-    StepVerifier.create(refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId))
+    StepVerifier.create(
+        refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId, correlationId))
       .assertNext { assertEquals(operationId, it.operationId) }
       .verifyComplete()
     verify(npgClient, times(1))
@@ -124,6 +126,7 @@ class RefundServiceTests {
   ) {
     val operationId = "operationID"
     val idempotenceKey = UUID.randomUUID()
+    val correlationId = UUID.randomUUID().toString()
     val amount = BigDecimal.valueOf(1000)
     val pspId = "pspId1"
     // Precondition
@@ -142,7 +145,8 @@ class RefundServiceTests {
     given(spanBuilder.startSpan()).willReturn(span)
 
     // Test
-    StepVerifier.create(refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId))
+    StepVerifier.create(
+        refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId, correlationId))
       .expectError(expectedException)
       .verify()
     verify(npgClient, times(1))
@@ -157,6 +161,7 @@ class RefundServiceTests {
   ) {
     val operationId = "operationID"
     val idempotenceKey = UUID.randomUUID()
+    val correlationId = UUID.randomUUID().toString()
     val amount = BigDecimal.valueOf(1000)
     val pspId = "pspId1"
     // Precondition
@@ -167,7 +172,8 @@ class RefundServiceTests {
     given(spanBuilder.startSpan()).willReturn(span)
 
     // Test
-    StepVerifier.create(refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId))
+    StepVerifier.create(
+        refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId, correlationId))
       .expectError(expectedException)
       .verify()
     verify(npgClient, times(1))
@@ -180,6 +186,7 @@ class RefundServiceTests {
     val refundService = RefundService(paymentGatewayClient, npgClient, npgPspApiKeys)
     val operationId = "operationID"
     val idempotenceKey = UUID.randomUUID()
+    val correlationId = UUID.randomUUID().toString()
     val amount = BigDecimal.valueOf(1000)
     val pspId = "pspId1"
     // Precondition
@@ -190,7 +197,8 @@ class RefundServiceTests {
             "NPG error", listOf(), Optional.empty(), RuntimeException("NPG error"))))
 
     // Test
-    StepVerifier.create(refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId))
+    StepVerifier.create(
+        refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId, correlationId))
       .expectError(RefundNotAllowedException::class.java)
       .verify()
     verify(npgClient, times(1))
@@ -203,12 +211,14 @@ class RefundServiceTests {
     val refundService = RefundService(paymentGatewayClient, npgClient, npgPspApiKeys)
     val operationId = "operationID"
     val idempotenceKey = UUID.randomUUID()
+    val correlationId = UUID.randomUUID().toString()
     val amount = BigDecimal.valueOf(1000)
     val pspId = "unknown"
     // Precondition
 
     // Test
-    StepVerifier.create(refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId))
+    StepVerifier.create(
+        refundService.requestNpgRefund(operationId, idempotenceKey, amount, pspId, correlationId))
       .expectError(NpgApiKeyMissingPspRequestedException::class.java)
       .verify()
     verify(npgClient, times(0)).refundPayment(any(), any(), any(), any(), any(), any())


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Used the correlationId present in the activation event to make the refund  request to NPG.
<!--- Describe your changes in detail -->

#### Motivation and Context
The change was made to handle with a single correlationId all the transaction of NPG in this PR the logic for the refund  is unified
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.