### PR TITLE
fix: add cache delete after user transaction cancellation close payment

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionClosePaymentQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionClosePaymentQueueConsumer.kt
@@ -10,6 +10,7 @@ import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
 import it.pagopa.ecommerce.commons.queues.QueueEvent
 import it.pagopa.ecommerce.commons.queues.TracingInfo
 import it.pagopa.ecommerce.commons.queues.TracingUtils
+import it.pagopa.ecommerce.commons.redis.templatewrappers.PaymentRequestInfoRedisTemplateWrapper
 import it.pagopa.ecommerce.eventdispatcher.exceptions.*
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsEventStoreRepository
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsViewRepository
@@ -40,6 +41,8 @@ class TransactionClosePaymentQueueConsumer(
   @Autowired private val closureRetryService: ClosureRetryService,
   @Autowired private val deadLetterTracedQueueAsyncClient: DeadLetterTracedQueueAsyncClient,
   @Autowired private val tracingUtils: TracingUtils,
+  @Autowired
+  private val paymentRequestInfoRedisTemplateWrapper: PaymentRequestInfoRedisTemplateWrapper,
 ) {
   var logger: Logger = LoggerFactory.getLogger(TransactionClosePaymentQueueConsumer::class.java)
 
@@ -129,6 +132,12 @@ class TransactionClosePaymentQueueConsumer(
                 } else {
                   Mono.empty()
                 }
+              }
+            }
+            .doFinally {
+              tx.paymentNotices.forEach { el ->
+                logger.info("Invalidate cache for RptId : {}", el.rptId().value())
+                paymentRequestInfoRedisTemplateWrapper.deleteById(el.rptId().value())
               }
             }
         }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add cache delete after invoking node close payment for user transaction cancellation flow
<!--- Describe your changes in detail -->

#### Motivation and Context
This fix restore the payment cache delete logic after the user cancel the transaction
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.