### PR TITLE
fix(v2): missing closure error event in case of refund after close payment

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -292,7 +292,6 @@ class ClosePaymentHelper(
       .publishOn(Schedulers.boundedElastic())
       .doOnError(NoRetryAttemptsLeftException::class.java) { exception ->
         logger.error("No more attempts left for closure retry", exception)
-        refundTransactionPipeline(baseTransaction, TransactionClosureData.Outcome.KO, tracingInfo)
       }
 
   private fun updateTransactionToClosureError(baseTransaction: BaseTransaction) =

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -239,58 +239,61 @@ class ClosePaymentHelper(
     retryCount: Int,
     tracingInfo: TracingInfo,
   ) =
-    baseTransaction.publishOn(Schedulers.boundedElastic()).flatMap { tx ->
-      logger.error(
-        "Got exception while retrying closePaymentV2 for transaction with id ${tx.transactionId}!",
-        exception)
-      val (statusCode, errorDescription) =
-        if (exception is ClosePaymentErrorResponseException) {
-          Pair(exception.statusCode, exception.errorResponse?.description)
+    baseTransaction
+      .publishOn(Schedulers.boundedElastic())
+      .flatMap { tx ->
+        logger.error(
+          "Got exception while processing closePaymentV2 for transaction with id ${tx.transactionId.value()}!",
+          exception)
+        updateTransactionToClosureError(tx)
+      }
+      .flatMap { tx ->
+        val (statusCode, errorDescription) =
+          if (exception is ClosePaymentErrorResponseException) {
+            Pair(exception.statusCode, exception.errorResponse?.description)
+          } else {
+            Pair(null, null)
+          }
+        // transaction can be refund only for HTTP status code 422 and error response description
+        // equals to "Node did not receive RPT yet"
+        val refundTransaction =
+          statusCode == HttpStatus.UNPROCESSABLE_ENTITY &&
+            errorDescription == NodeClient.NODE_DID_NOT_RECEIVE_RPT_YET_ERROR
+        // retry event enqueued only for 5xx error responses or for other exceptions that might
+        // happen
+        // during communication such as read timeout
+        val enqueueRetryEvent =
+          !refundTransaction && (statusCode == null || statusCode.is5xxServerError)
+        logger.info(
+          "Handling Nodo close payment error response. Status code: [{}], error description: [{}] -> refund transaction: [{}], enqueue retry event: [{}]",
+          statusCode,
+          errorDescription,
+          refundTransaction,
+          enqueueRetryEvent)
+        if (refundTransaction) {
+          refundTransactionPipeline(tx, TransactionClosureData.Outcome.KO, tracingInfo).then()
         } else {
-          Pair(null, null)
-        }
-      // transaction can be refund only for HTTP status code 422 and error response description
-      // equals to "Node did not receive RPT yet"
-      val refundTransaction =
-        statusCode == HttpStatus.UNPROCESSABLE_ENTITY &&
-          errorDescription == NodeClient.NODE_DID_NOT_RECEIVE_RPT_YET_ERROR
-      // retry event enqueued only for 5xx error responses or for other exceptions that might happen
-      // during communication such as read timeout
-      val enqueueRetryEvent =
-        !refundTransaction && (statusCode == null || statusCode.is5xxServerError)
-      logger.info(
-        "Handling Nodo close payment error response. Status code: [{}], error description: [{}] -> refund transaction: [{}], enqueue retry event: [{}]",
-        statusCode,
-        errorDescription,
-        refundTransaction,
-        enqueueRetryEvent)
-      if (refundTransaction) {
-        refundTransactionPipeline(tx, TransactionClosureData.Outcome.KO, tracingInfo).then()
-      } else {
-        if (enqueueRetryEvent) {
-          enqueueClosureRetryEventPipeline(
-            baseTransaction = tx, retryCount = retryCount, tracingInfo = tracingInfo)
-        } else {
-          updateTransactionToClosureError(tx).then()
+          if (enqueueRetryEvent) {
+            enqueueClosureRetryEventPipeline(
+              baseTransaction = tx, retryCount = retryCount, tracingInfo = tracingInfo)
+          } else {
+            Mono.empty()
+          }
         }
       }
-    }
 
   private fun enqueueClosureRetryEventPipeline(
     baseTransaction: BaseTransaction,
     retryCount: Int,
     tracingInfo: TracingInfo
   ) =
-    updateTransactionToClosureError(baseTransaction)
-      .then(
-        closureRetryService
-          .enqueueRetryEvent(baseTransaction, retryCount, tracingInfo)
-          .publishOn(Schedulers.boundedElastic())
-          .doOnError(NoRetryAttemptsLeftException::class.java) { exception ->
-            logger.error("No more attempts left for closure retry", exception)
-            refundTransactionPipeline(
-              baseTransaction, TransactionClosureData.Outcome.KO, tracingInfo)
-          })
+    closureRetryService
+      .enqueueRetryEvent(baseTransaction, retryCount, tracingInfo)
+      .publishOn(Schedulers.boundedElastic())
+      .doOnError(NoRetryAttemptsLeftException::class.java) { exception ->
+        logger.error("No more attempts left for closure retry", exception)
+        refundTransactionPipeline(baseTransaction, TransactionClosureData.Outcome.KO, tracingInfo)
+      }
 
   private fun updateTransactionToClosureError(baseTransaction: BaseTransaction) =
     if (baseTransaction.status != TransactionStatusDto.CLOSURE_ERROR) {

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
@@ -574,7 +574,7 @@ class ClosePaymentHelperTests {
   }
 
   @Test
-  fun `consumer perform refund for authorized transaction and close payment response outcome KO`() =
+  fun `consumer perform refund for authorized transaction and close payment response outcome KO for transaction in closure error status`() =
     runTest {
       val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
       val authorizationRequestEvent =
@@ -682,94 +682,98 @@ class ClosePaymentHelperTests {
     }
 
   @Test
-  fun `consumer enqueue retry event in case of error processing the received event`() = runTest {
-    val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
-    val authorizationRequestEvent =
-      transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
-    val authorizationCompleteEvent =
-      transactionAuthorizationCompletedEvent(
-        PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
-        as TransactionEvent<Any>
-    val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
-    val closureErrorEvent = transactionClosureErrorEvent() as TransactionEvent<Any>
+  fun `consumer enqueue retry event in case of error processing the received event for transaction in closure error status`() =
+    runTest {
+      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+      val authorizationRequestEvent =
+        transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+      val authorizationCompleteEvent =
+        transactionAuthorizationCompletedEvent(
+          PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
+          as TransactionEvent<Any>
+      val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+      val closureErrorEvent = transactionClosureErrorEvent() as TransactionEvent<Any>
 
-    val events =
-      listOf(
-        activationEvent,
-        authorizationRequestEvent,
-        authorizationCompleteEvent,
-        closureRequestedEvent,
-        closureErrorEvent)
+      val events =
+        listOf(
+          activationEvent,
+          authorizationRequestEvent,
+          authorizationCompleteEvent,
+          closureRequestedEvent,
+          closureErrorEvent)
 
-    /* preconditions */
-    given(checkpointer.success()).willReturn(Mono.empty())
-    given(
-        transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID))
-      .willReturn(events.toFlux())
-    given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
-      .willReturn(
-        Mono.just(
-          transactionDocument(
-            TransactionStatusDto.CLOSURE_ERROR, ZonedDateTime.parse(activationEvent.creationDate))))
-    given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willReturn {
-      Mono.error(RuntimeException("Error updating view"))
-    }
-    given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
-      .willAnswer { Mono.just(it.arguments[0]) }
-    given(
-        transactionsRefundedEventStoreRepository.save(refundedEventStoreRepositoryCaptor.capture()))
-      .willAnswer { Mono.just(it.arguments[0]) }
-    given(paymentGatewayClient.requestVPosRefund(any()))
-      .willReturn(
-        Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
-    given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
-      .willReturn(
-        ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.KO })
-    given(closureRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture(), any()))
-      .willReturn(Mono.empty())
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+            TRANSACTION_ID))
+        .willReturn(events.toFlux())
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturn(
+          Mono.just(
+            transactionDocument(
+              TransactionStatusDto.CLOSURE_ERROR,
+              ZonedDateTime.parse(activationEvent.creationDate))))
+      given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willReturn {
+        Mono.error(RuntimeException("Error updating view"))
+      }
+      given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            refundedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(
+          Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+      given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
+        .willReturn(
+          ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.KO })
+      given(closureRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture(), any()))
+        .willReturn(Mono.empty())
 
-    /* test */
+      /* test */
 
-    StepVerifier.create(
-        closePaymentHelper.closePayment(
-          ClosePaymentEvent.errored(
-            QueueEvent(closureErrorEvent as TransactionClosureErrorEvent, MOCK_TRACING_INFO)),
-          checkpointer,
-          EmptyTransaction()))
-      .expectNext(Unit)
-      .verifyComplete()
+      StepVerifier.create(
+          closePaymentHelper.closePayment(
+            ClosePaymentEvent.errored(
+              QueueEvent(closureErrorEvent as TransactionClosureErrorEvent, MOCK_TRACING_INFO)),
+            checkpointer,
+            EmptyTransaction()))
+        .expectNext(Unit)
+        .verifyComplete()
 
-    /* Asserts */
-    verify(checkpointer, Mockito.times(1)).success()
-    verify(nodeService, Mockito.times(1))
-      .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
-    verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
-    verify(transactionClosedEventRepository, Mockito.times(1)).save(any())
-    verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
-    verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
-    verify(transactionsViewRepository, Mockito.times(1)).save(any())
+      /* Asserts */
+      verify(checkpointer, Mockito.times(1)).success()
+      verify(nodeService, Mockito.times(1))
+        .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
+      verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+      verify(transactionClosedEventRepository, Mockito.times(1)).save(any())
+      verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
+      verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
+      verify(transactionsViewRepository, Mockito.times(1)).save(any())
 
-    verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any())
+      verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any())
 
-    val expectedViewUpdateStatuses =
-      listOf(
-        TransactionStatusDto.CLOSED,
-      )
+      val expectedViewUpdateStatuses =
+        listOf(
+          TransactionStatusDto.CLOSED,
+        )
 
-    expectedViewUpdateStatuses.forEachIndexed { idx, transactionStatusDto ->
+      expectedViewUpdateStatuses.forEachIndexed { idx, transactionStatusDto ->
+        assertEquals(
+          transactionStatusDto,
+          viewArgumentCaptor.allValues[idx].status,
+          "Unexpected view status update at idx: $idx")
+      }
       assertEquals(
-        transactionStatusDto,
-        viewArgumentCaptor.allValues[idx].status,
-        "Unexpected view status update at idx: $idx")
+        TransactionEventCode.TRANSACTION_CLOSED_EVENT,
+        TransactionEventCode.valueOf(closedEventStoreRepositoryCaptor.value.eventCode))
+      assertEquals(
+        TransactionClosureData.Outcome.KO,
+        closedEventStoreRepositoryCaptor.value.data.responseOutcome)
+      assertEquals(0, retryCountCaptor.value)
     }
-    assertEquals(
-      TransactionEventCode.TRANSACTION_CLOSED_EVENT,
-      TransactionEventCode.valueOf(closedEventStoreRepositoryCaptor.value.eventCode))
-    assertEquals(
-      TransactionClosureData.Outcome.KO,
-      closedEventStoreRepositoryCaptor.value.data.responseOutcome)
-    assertEquals(0, retryCountCaptor.value)
-  }
 
   @Test
   fun `consumer enqueue retry event in case of error processing the input retry event`() = runTest {
@@ -1542,7 +1546,7 @@ class ClosePaymentHelperTests {
     }
 
   @Test
-  fun `consumer perform refund for authorized transaction and close payment response with http error code 422 and error description Node did not receive RPT yet`() =
+  fun `consumer perform refund for authorized transaction and close payment response with http error code 422 and error description Node did not receive RPT yet for transaction in closure error state`() =
     runTest {
       val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
       val authorizationRequestEvent =
@@ -1644,7 +1648,7 @@ class ClosePaymentHelperTests {
     }
 
   @Test
-  fun `consumer does not perform refund for authorized transaction and close payment response with http error code 422 and error not expected description`() =
+  fun `consumer does not perform refund for authorized transaction and close payment response with http error code 422 and error not expected description for transaction in closure error state`() =
     runTest {
       val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
       val authorizationRequestEvent =
@@ -1816,7 +1820,7 @@ class ClosePaymentHelperTests {
     }
 
   @Test
-  fun `consumer should stop retry and not perform refund for Node closePayment responses with http code 4xx`() =
+  fun `consumer should stop retry and not perform refund for Node closePayment responses with http code 4xx for transaction in closure error state`() =
     runTest {
       val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
       val authorizationRequestEvent =
@@ -1911,7 +1915,7 @@ class ClosePaymentHelperTests {
 
   @ParameterizedTest
   @MethodSource("nodeErrorResponsesForEnqueueRetryTest")
-  fun `consumer should closure retry event for Node close payment error response code 5xx`(
+  fun `consumer should write closure retry event for Node close payment error response code 5xx for transaction in closure error state`(
     throwable: Throwable
   ) = runTest {
     val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
@@ -1983,4 +1987,616 @@ class ClosePaymentHelperTests {
     verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any())
     assertEquals(0, retryCountCaptor.value)
   }
+
+  @Test
+  fun `consumer perform refund for authorized transaction and close payment response with http error code 422 and error description Node did not receive RPT yet for transaction in closure requested state`() =
+    runTest {
+      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+      val authorizationRequestEvent =
+        transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+      val authorizationCompleteEvent =
+        transactionAuthorizationCompletedEvent(
+          PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
+          as TransactionEvent<Any>
+      val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+
+      val events =
+        listOf(
+          activationEvent,
+          authorizationRequestEvent,
+          authorizationCompleteEvent,
+          closureRequestedEvent)
+
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+            TRANSACTION_ID))
+        .willReturn(events.toFlux())
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSURE_ERROR,
+                ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSED, ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.REFUND_REQUESTED,
+                ZonedDateTime.parse(activationEvent.creationDate)))))
+      given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willAnswer {
+        Mono.just(it.arguments[0])
+      }
+
+      given(
+          transactionClosureErrorEventStoreRepository.save(
+            closureErrorEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            refundedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(
+          Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+      given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
+        .willThrow(
+          ClosePaymentErrorResponseException(
+            statusCode = HttpStatus.UNPROCESSABLE_ENTITY,
+            errorResponse = ErrorDto().outcome("KO").description("Node did not receive RPT yet")))
+
+      /* test */
+
+      StepVerifier.create(
+          closePaymentHelper.closePayment(
+            ClosePaymentEvent.requested(
+              QueueEvent(
+                closureRequestedEvent as TransactionClosureRequestedEvent, MOCK_TRACING_INFO)),
+            checkpointer,
+            EmptyTransaction()))
+        .expectNext(Unit)
+        .verifyComplete()
+
+      /* Asserts */
+      verify(checkpointer, Mockito.times(1)).success()
+      verify(nodeService, Mockito.times(1))
+        .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
+      verify(paymentGatewayClient, times(1)).requestVPosRefund(any())
+      verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
+      verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
+      verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
+      verify(transactionsRefundedEventStoreRepository, Mockito.times(2)).save(any())
+      verify(transactionsViewRepository, Mockito.times(3)).save(any())
+      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+
+      val expectedViewUpdateStatuses =
+        listOf(
+          TransactionStatusDto.CLOSURE_ERROR,
+          TransactionStatusDto.REFUND_REQUESTED,
+          TransactionStatusDto.REFUNDED)
+      val expectedEventsCodes =
+        listOf(
+          TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT)
+      expectedViewUpdateStatuses.forEachIndexed { idx, transactionStatusDto ->
+        assertEquals(
+          transactionStatusDto,
+          viewArgumentCaptor.allValues[idx].status,
+          "Unexpected view status update at idx: $idx")
+      }
+
+      expectedEventsCodes.forEachIndexed { idx, transactionEventCode ->
+        assertEquals(
+          transactionEventCode,
+          TransactionEventCode.valueOf(refundedEventStoreRepositoryCaptor.allValues[idx].eventCode),
+          "Unexpected event at idx: $idx")
+      }
+      assertEquals(
+        TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT.name,
+        closureErrorEventStoreRepositoryCaptor.value.eventCode)
+    }
+
+  @Test
+  fun `consumer does not perform refund for authorized transaction and close payment response with http error code 422 and error not expected description for transaction in closure requested state`() =
+    runTest {
+      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+      val authorizationRequestEvent =
+        transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+      val authorizationCompleteEvent =
+        transactionAuthorizationCompletedEvent(
+          PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
+          as TransactionEvent<Any>
+      val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+
+      val events =
+        listOf(
+          activationEvent,
+          authorizationRequestEvent,
+          authorizationCompleteEvent,
+          closureRequestedEvent)
+
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+            TRANSACTION_ID))
+        .willReturn(events.toFlux())
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSURE_ERROR,
+                ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSED, ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.REFUND_REQUESTED,
+                ZonedDateTime.parse(activationEvent.creationDate)))))
+      given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willAnswer {
+        Mono.just(it.arguments[0])
+      }
+
+      given(
+          transactionClosureErrorEventStoreRepository.save(
+            closureErrorEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            refundedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(
+          Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+      given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
+        .willThrow(
+          ClosePaymentErrorResponseException(
+            statusCode = HttpStatus.UNPROCESSABLE_ENTITY,
+            errorResponse = ErrorDto().outcome("KO").description("unknown error")))
+
+      /* test */
+
+      StepVerifier.create(
+          closePaymentHelper.closePayment(
+            ClosePaymentEvent.requested(
+              QueueEvent(
+                closureRequestedEvent as TransactionClosureRequestedEvent, MOCK_TRACING_INFO)),
+            checkpointer,
+            EmptyTransaction()))
+        .expectNext(Unit)
+        .verifyComplete()
+
+      /* Asserts */
+      verify(checkpointer, Mockito.times(1)).success()
+      verify(nodeService, Mockito.times(1))
+        .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
+      verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+      verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
+      verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
+      verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
+      verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
+      verify(transactionsViewRepository, Mockito.times(1)).save(any())
+      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
+      assertEquals(
+        TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT.name,
+        closureErrorEventStoreRepositoryCaptor.value.eventCode)
+    }
+
+  @Test
+  fun `consumer should stop retry and not perform refund for Node closePayment responses with http code 4xx for transaction in closure requested state`() =
+    runTest {
+      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+      val authorizationRequestEvent =
+        transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+      val authorizationCompleteEvent =
+        transactionAuthorizationCompletedEvent(
+          PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
+          as TransactionEvent<Any>
+      val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+
+      val events =
+        listOf(
+          activationEvent,
+          authorizationRequestEvent,
+          authorizationCompleteEvent,
+          closureRequestedEvent)
+
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+            TRANSACTION_ID))
+        .willReturn(events.toFlux())
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSURE_ERROR,
+                ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSED, ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.REFUND_REQUESTED,
+                ZonedDateTime.parse(activationEvent.creationDate)))))
+      given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willAnswer {
+        Mono.just(it.arguments[0])
+      }
+      given(
+          transactionClosureErrorEventStoreRepository.save(
+            closureErrorEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            refundedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(
+          Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+      given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
+        .willThrow(
+          ClosePaymentErrorResponseException(
+            statusCode = HttpStatus.BAD_REQUEST,
+            errorResponse = ErrorDto().outcome("KO").description("bad request error")))
+
+      /* test */
+
+      StepVerifier.create(
+          closePaymentHelper.closePayment(
+            ClosePaymentEvent.requested(
+              QueueEvent(
+                closureRequestedEvent as TransactionClosureRequestedEvent, MOCK_TRACING_INFO)),
+            checkpointer,
+            EmptyTransaction()))
+        .expectNext(Unit)
+        .verifyComplete()
+
+      /* Asserts */
+      verify(checkpointer, Mockito.times(1)).success()
+      verify(nodeService, Mockito.times(1))
+        .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
+      verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+      verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
+      verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
+      verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
+      verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
+      verify(transactionsViewRepository, Mockito.times(1)).save(any())
+      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
+      assertEquals(
+        TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT.name,
+        closureErrorEventStoreRepositoryCaptor.value.eventCode)
+    }
+
+  @ParameterizedTest
+  @MethodSource("nodeErrorResponsesForEnqueueRetryTest")
+  fun `consumer should write closure retry event for Node close payment error response code 5xx for transaction in closure requested state`(
+    throwable: Throwable
+  ) = runTest {
+    val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+    val authorizationRequestEvent =
+      transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+    val authorizationCompleteEvent =
+      transactionAuthorizationCompletedEvent(
+        PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
+        as TransactionEvent<Any>
+    val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+
+    val events =
+      listOf(
+        activationEvent,
+        authorizationRequestEvent,
+        authorizationCompleteEvent,
+        closureRequestedEvent)
+
+    /* preconditions */
+    given(checkpointer.success()).willReturn(Mono.empty())
+    given(
+        transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID))
+      .willReturn(events.toFlux())
+    given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(
+        Mono.just(
+          transactionDocument(
+            TransactionStatusDto.CLOSURE_ERROR, ZonedDateTime.parse(activationEvent.creationDate))))
+    given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willAnswer {
+      Mono.just(it.arguments[0])
+    }
+    given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
+      .willAnswer { Mono.just(it.arguments[0]) }
+    given(
+        transactionClosureErrorEventStoreRepository.save(
+          closureErrorEventStoreRepositoryCaptor.capture()))
+      .willAnswer { Mono.just(it.arguments[0]) }
+    given(
+        transactionsRefundedEventStoreRepository.save(refundedEventStoreRepositoryCaptor.capture()))
+      .willAnswer { Mono.just(it.arguments[0]) }
+    given(paymentGatewayClient.requestVPosRefund(any()))
+      .willReturn(
+        Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+    given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
+      .willThrow(throwable)
+
+    given(closureRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture(), any()))
+      .willReturn(Mono.empty())
+
+    /* test */
+    Hooks.onOperatorDebug()
+    StepVerifier.create(
+        closePaymentHelper.closePayment(
+          ClosePaymentEvent.requested(
+            QueueEvent(
+              closureRequestedEvent as TransactionClosureRequestedEvent, MOCK_TRACING_INFO)),
+          checkpointer,
+          EmptyTransaction()))
+      .expectNext(Unit)
+      .verifyComplete()
+
+    /* Asserts */
+    verify(checkpointer, Mockito.times(1)).success()
+    verify(nodeService, Mockito.times(1))
+      .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
+    verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+    verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
+    verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
+    verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
+    verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
+    verify(transactionsViewRepository, Mockito.times(1)).save(any())
+
+    verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any())
+    assertEquals(0, retryCountCaptor.value)
+    assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
+    assertEquals(
+      TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT.name,
+      closureErrorEventStoreRepositoryCaptor.value.eventCode)
+  }
+
+  @Test
+  fun `consumer perform refund for authorized transaction and close payment response outcome KO for transaction in closure requested status`() =
+    runTest {
+      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+      val authorizationRequestEvent =
+        transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+      val authorizationCompleteEvent =
+        transactionAuthorizationCompletedEvent(
+          PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
+          as TransactionEvent<Any>
+      val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+
+      val events =
+        listOf(
+          activationEvent,
+          authorizationRequestEvent,
+          authorizationCompleteEvent,
+          closureRequestedEvent)
+
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+            TRANSACTION_ID))
+        .willReturn(events.toFlux())
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturnConsecutively(
+          listOf(
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSURE_ERROR,
+                ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.CLOSED, ZonedDateTime.parse(activationEvent.creationDate))),
+            Mono.just(
+              transactionDocument(
+                TransactionStatusDto.REFUND_REQUESTED,
+                ZonedDateTime.parse(activationEvent.creationDate)))))
+      given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willAnswer {
+        Mono.just(it.arguments[0])
+      }
+      given(
+          transactionClosureErrorEventStoreRepository.save(
+            closureErrorEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            refundedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(
+          Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+      given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
+        .willReturn(
+          ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.KO })
+
+      /* test */
+
+      StepVerifier.create(
+          closePaymentHelper.closePayment(
+            ClosePaymentEvent.requested(
+              QueueEvent(
+                closureRequestedEvent as TransactionClosureRequestedEvent, MOCK_TRACING_INFO)),
+            checkpointer,
+            EmptyTransaction()))
+        .expectNext(Unit)
+        .verifyComplete()
+
+      /* Asserts */
+      verify(checkpointer, Mockito.times(1)).success()
+      verify(nodeService, Mockito.times(1))
+        .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
+      verify(paymentGatewayClient, times(1)).requestVPosRefund(any())
+      verify(transactionClosedEventRepository, Mockito.times(1)).save(any())
+      verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
+      verify(transactionsRefundedEventStoreRepository, Mockito.times(2)).save(any())
+      verify(transactionsViewRepository, Mockito.times(3)).save(any())
+      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+
+      val expectedViewUpdateStatuses =
+        listOf(
+          TransactionStatusDto.CLOSED,
+          TransactionStatusDto.REFUND_REQUESTED,
+          TransactionStatusDto.REFUNDED)
+      val expectedEventsCodes =
+        listOf(
+          TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT,
+          TransactionEventCode.TRANSACTION_REFUNDED_EVENT)
+      expectedViewUpdateStatuses.forEachIndexed { idx, transactionStatusDto ->
+        assertEquals(
+          transactionStatusDto,
+          viewArgumentCaptor.allValues[idx].status,
+          "Unexpected view status update at idx: $idx")
+      }
+      assertEquals(
+        TransactionEventCode.TRANSACTION_CLOSED_EVENT,
+        TransactionEventCode.valueOf(closedEventStoreRepositoryCaptor.value.eventCode))
+      assertEquals(
+        TransactionClosureData.Outcome.KO,
+        closedEventStoreRepositoryCaptor.value.data.responseOutcome)
+      expectedEventsCodes.forEachIndexed { idx, transactionEventCode ->
+        assertEquals(
+          transactionEventCode,
+          TransactionEventCode.valueOf(refundedEventStoreRepositoryCaptor.allValues[idx].eventCode),
+          "Unexpected event at idx: $idx")
+      }
+    }
+
+  @Test
+  fun `consumer enqueue retry event in case of error processing the received event for transaction in closure requested status`() =
+    runTest {
+      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+      val authorizationRequestEvent =
+        transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+      val authorizationCompleteEvent =
+        transactionAuthorizationCompletedEvent(
+          PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK))
+          as TransactionEvent<Any>
+      val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+
+      val events =
+        listOf(
+          activationEvent,
+          authorizationRequestEvent,
+          authorizationCompleteEvent,
+          closureRequestedEvent)
+
+      /* preconditions */
+      given(checkpointer.success()).willReturn(Mono.empty())
+      given(
+          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+            TRANSACTION_ID))
+        .willReturn(events.toFlux())
+      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+        .willReturn(
+          Mono.just(
+            transactionDocument(
+              TransactionStatusDto.CLOSURE_REQUESTED,
+              ZonedDateTime.parse(activationEvent.creationDate))),
+          Mono.just(
+            transactionDocument(
+              TransactionStatusDto.CLOSURE_REQUESTED,
+              ZonedDateTime.parse(activationEvent.creationDate))))
+      given(transactionsViewRepository.save(viewArgumentCaptor.capture()))
+        .willReturn(Mono.error(RuntimeException("Error updating view")))
+      given(
+          transactionClosureErrorEventStoreRepository.save(
+            closureErrorEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(
+          transactionsRefundedEventStoreRepository.save(
+            refundedEventStoreRepositoryCaptor.capture()))
+        .willAnswer { Mono.just(it.arguments[0]) }
+      given(paymentGatewayClient.requestVPosRefund(any()))
+        .willReturn(
+          Mono.just(VposDeleteResponseDto().status(VposDeleteResponseDto.StatusEnum.CANCELLED)))
+      given(nodeService.closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK))
+        .willReturn(
+          ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.KO })
+      given(closureRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture(), any()))
+        .willReturn(Mono.empty())
+      given(
+          deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
+            any<BinaryData>(), any()))
+        .willReturn(mono {})
+
+      /* test */
+      Hooks.onOperatorDebug()
+      StepVerifier.create(
+          closePaymentHelper.closePayment(
+            ClosePaymentEvent.requested(
+              QueueEvent(
+                closureRequestedEvent as TransactionClosureRequestedEvent, MOCK_TRACING_INFO)),
+            checkpointer,
+            EmptyTransaction()))
+        .expectNext(Unit)
+        .verifyComplete()
+
+      /* Asserts */
+      verify(checkpointer, Mockito.times(1)).success()
+      verify(nodeService, Mockito.times(1))
+        .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.OK)
+      verify(paymentGatewayClient, times(0)).requestVPosRefund(any())
+      verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
+      verify(transactionClosedEventRepository, Mockito.times(1)).save(any())
+      verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
+      verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
+      verify(transactionsViewRepository, Mockito.times(2)).save(any())
+
+      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+      verify(deadLetterTracedQueueAsyncClient, times(1))
+        .sendAndTraceDeadLetterQueueEvent(
+          argThat<BinaryData> {
+            TransactionEventCode.valueOf(
+              this.toObject(
+                  object : TypeReference<QueueEvent<TransactionClosureRequestedEvent>>() {},
+                  jsonSerializerV2)
+                .event
+                .eventCode) == TransactionEventCode.TRANSACTION_CLOSURE_REQUESTED_EVENT
+          },
+          eq(
+            DeadLetterTracedQueueAsyncClient.ErrorContext(
+              transactionId = TransactionId(TRANSACTION_ID),
+              transactionEventCode =
+                TransactionEventCode.TRANSACTION_CLOSURE_REQUESTED_EVENT.toString(),
+              errorCategory = DeadLetterTracedQueueAsyncClient.ErrorCategory.PROCESSING_ERROR)),
+        )
+      val expectedViewUpdateStatuses =
+        listOf(
+          TransactionStatusDto.CLOSED,
+          TransactionStatusDto.CLOSURE_ERROR,
+        )
+
+      expectedViewUpdateStatuses.forEachIndexed { idx, transactionStatusDto ->
+        assertEquals(
+          transactionStatusDto,
+          viewArgumentCaptor.allValues[idx].status,
+          "Unexpected view status update at idx: $idx")
+      }
+      assertEquals(
+        TransactionEventCode.TRANSACTION_CLOSED_EVENT,
+        TransactionEventCode.valueOf(closedEventStoreRepositoryCaptor.value.eventCode))
+      assertEquals(
+        TransactionClosureData.Outcome.KO,
+        closedEventStoreRepositoryCaptor.value.data.responseOutcome)
+      assertEquals(
+        TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT,
+        TransactionEventCode.valueOf(closureErrorEventStoreRepositoryCaptor.value.eventCode))
+    }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Add missing closure error event in case of transaction to be refund due to close payment KO response (422 HTTP error code with response `Node did not receive RPT yet`
- Remove `refundTransactionPipeline` pipeline call when no retry attempts are left for close payment retry since no refund have to be done in this case

<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to write the closure error event before the refund requested ones. Without closure error event, in fact, transactions event are inconsistent and reduce operation will not perform reduction successfully, discarding refunds events and thinking that transaction is in EXPIRATION status instead of REFUND_REQUESTED/REFUNDED ones
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local tests with eCommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.