### PR TITLE
[CHK-2812] feat(getstate): forward NPG `validationServiceId` if present in NPG `getState`

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -299,6 +299,8 @@ fun patchAuthRequestByState(
                   authorizationCode =
                     stateResponseDto.operation!!.additionalData!!["authorizationCode"] as String?
                   rrn = stateResponseDto.operation!!.additionalData!!["rrn"] as String?
+                  validationServiceId =
+                    stateResponseDto.operation!!.additionalData!!["validationServiceId"] as String?
                 }
                 paymentEndToEndId = stateResponseDto.operation!!.paymentEndToEndId
               }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
@@ -514,6 +514,7 @@ class NodeService(
                 authCompleted.transactionAuthorizationCompletedData.timestampOperation,
                 DateTimeFormatter.ISO_OFFSET_DATE_TIME)
             this.totalAmount = totalAmountEuro.toString()
+            this.email = it
           }
         }
         .map { Optional.of(it) }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
@@ -119,7 +119,7 @@ class AuhtorizationRequestedHelperTests {
 
   @ParameterizedTest
   @MethodSource("Recover transaction status timestamp method source")
-  fun `messageReceiver consume event correctly and receive PAYMENT_COMPLETE outcome from NPG`(
+  fun `messageReceiver consume event correctly and receive PAYMENT_COMPLETE outcome from NPG with card fields`(
     receivedOperationTime: String,
     expectedOperationTime: OffsetDateTime
   ) = runTest {
@@ -159,6 +159,107 @@ class AuhtorizationRequestedHelperTests {
             this.authorizationCode = authorizationCode
             this.paymentEndToEndId = paymentEndToEndId
             this.rrn = rrn
+          }
+        timestampOperation = expectedOperationTime
+      }
+
+    /* preconditions */
+    given(checkpointer.success()).willReturn(Mono.empty())
+    given(
+        transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+          any(),
+        ))
+      .willReturn(
+        Flux.just(
+          activatedEvent as TransactionEvent<Any>,
+          authorizationRequestedEvent as TransactionEvent<Any>,
+          authorizationOutcomeWaitingEvent as TransactionEvent<Any>,
+        ))
+
+    given(transactionsViewRepository.save(transactionViewRepositoryCaptor.capture())).willAnswer {
+      Mono.just(it.arguments[0])
+    }
+
+    given(
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), retryCountCaptor.capture(), any()))
+      .willReturn(Mono.empty())
+    given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(
+        Mono.just(
+          transactionDocument(
+            it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
+              .AUTHORIZATION_REQUESTED,
+            ZonedDateTime.now())))
+
+    given(authorizationStateRetrieverService.getStateNpg(any(), any(), any(), any(), any()))
+      .willReturn(mono { npgStateResponse })
+    given(transactionsServiceClient.patchAuthRequest(any(), any()))
+      .willReturn(
+        mono { TransactionInfoDto().status(TransactionStatusDto.AUTHORIZATION_COMPLETED) })
+    /* test */
+    StepVerifier.create(
+        authorizationRequestedHelper.authorizationStateRetrieve(
+          Either.right(
+            QueueEvent(authorizationOutcomeWaitingEvent, TracingInfoTest.MOCK_TRACING_INFO)),
+          checkpointer))
+      .expectNext(Unit)
+      .verifyComplete()
+
+    /* Asserts */
+    verify(checkpointer, times(1)).success()
+    verify(authorizationStateRetrieverRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+    verify(authorizationStateRetrieverService, times(1))
+      .getStateNpg(
+        transactionId,
+        expectedGetStateSessionId,
+        PSP_ID,
+        NPG_CORRELATION_ID,
+        NpgClient.PaymentMethod.CARDS)
+    verify(transactionsServiceClient, times(1))
+      .patchAuthRequest(transactionId, expectedPatchAuthRequest)
+  }
+
+  @ParameterizedTest
+  @MethodSource("Recover transaction status timestamp method source")
+  fun `messageReceiver consume event correctly and receive PAYMENT_COMPLETE outcome from NPG with MyBank fields`(
+    receivedOperationTime: String,
+    expectedOperationTime: OffsetDateTime
+  ) = runTest {
+    val activatedEvent = transactionActivateEvent(npgTransactionGatewayActivationData())
+    val authorizationRequestedEvent =
+      transactionAuthorizationRequestedEvent(
+        TransactionAuthorizationRequestData.PaymentGateway.NPG,
+        npgTransactionGatewayAuthorizationRequestedData())
+
+    val authorizationOutcomeWaitingEvent = transactionAuthorizationOutcomeWaitingEvent(1)
+    val transactionId = TransactionId(TRANSACTION_ID)
+    val operationId = "operationId"
+    val orderId = "orderId"
+    val validationServiceId = "123456"
+    val paymentEndToEndId = "paymentEndToEndId"
+    val npgStateResponse =
+      StateResponseDto()
+        .state(WorkflowStateDto.PAYMENT_COMPLETE)
+        .operation(
+          OperationDto()
+            .operationId(operationId)
+            .orderId(orderId)
+            .operationResult(OperationResultDto.EXECUTED)
+            .paymentEndToEndId(paymentEndToEndId)
+            .operationTime(receivedOperationTime)
+            .additionalData(mapOf("validationServiceId" to validationServiceId)))
+    val expectedGetStateSessionId = NPG_CONFIRM_PAYMENT_SESSION_ID
+    val expectedPatchAuthRequest =
+      UpdateAuthorizationRequestDto().apply {
+        outcomeGateway =
+          OutcomeNpgGatewayDto().apply {
+            this.paymentGatewayType = "NPG"
+            this.operationResult = OutcomeNpgGatewayDto.OperationResultEnum.EXECUTED
+            this.orderId = orderId
+            this.operationId = operationId
+            this.paymentEndToEndId = paymentEndToEndId
+            this.validationServiceId = validationServiceId
           }
         timestampOperation = expectedOperationTime
       }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
@@ -1602,6 +1602,7 @@ class NodeServiceTests {
               timestampOperation = OffsetDateTime.parse(expectedTimestamp)
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
+              this.email = EMAIL_STRING
             }
         }
 
@@ -3164,6 +3165,7 @@ class NodeServiceTests {
               timestampOperation = OffsetDateTime.parse(expectedTimestamp)
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
+              this.email = EMAIL_STRING
             }
         }
 
@@ -3903,6 +3905,7 @@ class NodeServiceTests {
               timestampOperation = OffsetDateTime.parse(expectedTimestamp)
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
+              this.email = EMAIL_STRING
             }
         }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
 * forward NPG `validationServiceId` (for MyBank) if present in NPG `getState`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR forwards `validationServiceId` field for MyBank when retrieving an authorization state when NPG didn't notify us.
This field is needed to be forwarded to the later `closePayment` phase.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.