### PR TITLE
feat: user notification for carts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>1.15.1</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>1.16.0</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**,
 			**/it/pagopa/ecommerce/eventdispatcher/validation/**
@@ -590,8 +590,6 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
-					<scmVersionType>branch</scmVersionType>
-					<scmVersion>CHK-2794-send-payment-result-data</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,8 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+					<scmVersion>CHK-2794-send-payment-result-data</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>1.15.0</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>1.15.1</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**,
 			**/it/pagopa/ecommerce/eventdispatcher/validation/**

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/v2/UserReceiptMailBuilder.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/v2/UserReceiptMailBuilder.kt
@@ -133,9 +133,8 @@ class UserReceiptMailBuilder(@Autowired private val confidentialDataUtils: Confi
                   RefNumberTemplate(Type.CODICE_AVVISO, paymentNotice.rptId().noticeId),
                   null,
                   PayeeTemplate(
-                    transactionUserReceiptData.receivingOfficeName ?: "",
-                    paymentNotice.rptId().fiscalCode),
-                  transactionUserReceiptData.paymentDescription,
+                    paymentNotice.companyName.value ?: "", paymentNotice.rptId().fiscalCode),
+                  paymentNotice.transactionDescription.value,
                   amountToHumanReadableString(paymentNotice.transactionAmount().value()))
               }
               .toList(),

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsQueueConsumerTest.kt
@@ -796,16 +796,14 @@ class TransactionNotificationsQueueConsumerTest {
       given(confidentialDataUtils.toEmail(any())).willReturn(Email("to@to.it"))
       val userReceiptBuilder = UserReceiptMailBuilder(confidentialDataUtils)
       val transactionUserReceiptData =
-        TransactionUserReceiptData(
-          TransactionUserReceiptData.Outcome.OK,
-          "it-IT",
-          PAYMENT_DATE,
-          "testValue",
-          "paymentDescription")
+        TransactionUserReceiptData(TransactionUserReceiptData.Outcome.OK, "it-IT", PAYMENT_DATE)
+      val companyName = "testCompanyName"
+      val transactionActivatedEvent = transactionActivateEvent()
+      transactionActivatedEvent.data.paymentNotices.forEach { it.companyName = companyName }
       val notificationRequested = transactionUserReceiptRequestedEvent(transactionUserReceiptData)
       val events =
         listOf(
-          transactionActivateEvent(),
+          transactionActivatedEvent,
           transactionAuthorizationRequestedEvent(),
           transactionAuthorizationCompletedEvent(
             PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK)),
@@ -825,7 +823,7 @@ class TransactionNotificationsQueueConsumerTest {
       val notificationEmailRequestDto =
         userReceiptBuilder.buildNotificationEmailRequestDto(baseTransaction)
       assertEquals(
-        "testValue",
+        companyName,
         (notificationEmailRequestDto.parameters as SuccessTemplate)
           .cart
           .items
@@ -841,12 +839,13 @@ class TransactionNotificationsQueueConsumerTest {
       given(confidentialDataUtils.toEmail(any())).willReturn(Email("to@to.it"))
       val userReceiptBuilder = UserReceiptMailBuilder(confidentialDataUtils)
       val transactionUserReceiptData =
-        TransactionUserReceiptData(
-          TransactionUserReceiptData.Outcome.OK, "it-IT", PAYMENT_DATE, null, "paymentDescription")
+        TransactionUserReceiptData(TransactionUserReceiptData.Outcome.OK, "it-IT", PAYMENT_DATE)
       val notificationRequested = transactionUserReceiptRequestedEvent(transactionUserReceiptData)
+      val transactionActivatedEvent = transactionActivateEvent()
+      transactionActivatedEvent.data.paymentNotices.forEach { it.companyName = null }
       val events =
         listOf(
-          transactionActivateEvent(),
+          transactionActivatedEvent,
           transactionAuthorizationRequestedEvent(),
           transactionAuthorizationCompletedEvent(
             PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK)),


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/194
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Use `companyName` and `description` into success mails `CartTemplate.ItemTemplate` instead of the first value received into send payment result outcome
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification fix mail request composition for those transactions with a cart of payment notices using the right value for each payment notice as received by Nodo in activate response body
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.