### PR TITLE
[CHK-2811] feat(getstate): forward `errorCode` from NPG when calling `getState`

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -323,6 +323,16 @@ fun getTimeStampOperation(operationTime: String): OffsetDateTime {
   return zonedDateTime.toOffsetDateTime()
 }
 
+/*
+ * @formatter:off
+ *
+ * Warning kotlin:S107 - Functions should not have too many parameters
+ * Suppressed because the inner business logic is complex
+ * TODO: will refactor into separate functions down the line
+ *
+ * @formatter:on
+ */
+@SuppressWarnings("kotlin:S107")
 fun refundTransaction(
   tx: BaseTransaction,
   transactionsEventStoreRepository: TransactionsEventStoreRepository<TransactionRefundedData>,
@@ -799,6 +809,16 @@ fun updateNotificationErrorTransactionStatus(
     .flatMap { transactionUserReceiptRepository.save(event) }
 }
 
+/*
+ * @formatter:off
+ *
+ * Warning kotlin:S107 - Functions should not have too many parameters
+ * Suppressed because the inner business logic is complex
+ * TODO: will refactor into separate functions down the line
+ *
+ * @formatter:on
+ */
+@SuppressWarnings("kotlin:S107")
 fun notificationRefundTransactionPipeline(
   transaction: BaseTransactionWithRequestedUserReceipt,
   transactionsRefundedEventStoreRepository:

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -670,6 +670,15 @@ fun getAuthorizationOutcome(tx: BaseTransaction): AuthorizationResultDto? =
     else -> null
   }
 
+/*
+ * @formatter:off
+ *
+ * Warning kotlin:S1871 - Two branches in a conditional structure should not have exactly the same implementation
+ * Suppressed because different branches correspond to different types and cannot be unified
+ *
+ * @formatter:on
+ */
+@SuppressWarnings("kotlin:S1871")
 fun getAuthorizationCompletedData(
   tx: BaseTransaction,
   authorizationStateRetrieverService: AuthorizationStateRetrieverService

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -301,6 +301,7 @@ fun patchAuthRequestByState(
                   rrn = stateResponseDto.operation!!.additionalData!!["rrn"] as String?
                   validationServiceId =
                     stateResponseDto.operation!!.additionalData!!["validationServiceId"] as String?
+                  errorCode = stateResponseDto.operation!!.additionalData!!["errorCode"] as String?
                 }
                 paymentEndToEndId = stateResponseDto.operation!!.paymentEndToEndId
               }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
@@ -321,6 +321,107 @@ class AuhtorizationRequestedHelperTests {
       .patchAuthRequest(transactionId, expectedPatchAuthRequest)
   }
 
+  @ParameterizedTest
+  @MethodSource("Recover transaction status timestamp method source")
+  fun `messageReceiver consume event correctly and receive PAYMENT_COMPLETE outcome from NPG with error fields`(
+    receivedOperationTime: String,
+    expectedOperationTime: OffsetDateTime
+  ) = runTest {
+    val activatedEvent = transactionActivateEvent(npgTransactionGatewayActivationData())
+    val authorizationRequestedEvent =
+      transactionAuthorizationRequestedEvent(
+        TransactionAuthorizationRequestData.PaymentGateway.NPG,
+        npgTransactionGatewayAuthorizationRequestedData())
+
+    val authorizationOutcomeWaitingEvent = transactionAuthorizationOutcomeWaitingEvent(1)
+    val transactionId = TransactionId(TRANSACTION_ID)
+    val operationId = "operationId"
+    val orderId = "orderId"
+    val errorCode = "errorCode"
+    val paymentEndToEndId = "paymentEndToEndId"
+    val npgStateResponse =
+      StateResponseDto()
+        .state(WorkflowStateDto.PAYMENT_COMPLETE)
+        .operation(
+          OperationDto()
+            .operationId(operationId)
+            .orderId(orderId)
+            .operationResult(OperationResultDto.EXECUTED)
+            .paymentEndToEndId(paymentEndToEndId)
+            .operationTime(receivedOperationTime)
+            .additionalData(mapOf("errorCode" to errorCode)))
+    val expectedGetStateSessionId = NPG_CONFIRM_PAYMENT_SESSION_ID
+    val expectedPatchAuthRequest =
+      UpdateAuthorizationRequestDto().apply {
+        outcomeGateway =
+          OutcomeNpgGatewayDto().apply {
+            this.paymentGatewayType = "NPG"
+            this.operationResult = OutcomeNpgGatewayDto.OperationResultEnum.EXECUTED
+            this.orderId = orderId
+            this.operationId = operationId
+            this.paymentEndToEndId = paymentEndToEndId
+            this.errorCode = errorCode
+          }
+        timestampOperation = expectedOperationTime
+      }
+
+    /* preconditions */
+    given(checkpointer.success()).willReturn(Mono.empty())
+    given(
+        transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+          any(),
+        ))
+      .willReturn(
+        Flux.just(
+          activatedEvent as TransactionEvent<Any>,
+          authorizationRequestedEvent as TransactionEvent<Any>,
+          authorizationOutcomeWaitingEvent as TransactionEvent<Any>,
+        ))
+
+    given(transactionsViewRepository.save(transactionViewRepositoryCaptor.capture())).willAnswer {
+      Mono.just(it.arguments[0])
+    }
+
+    given(
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), retryCountCaptor.capture(), any()))
+      .willReturn(Mono.empty())
+    given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(
+        Mono.just(
+          transactionDocument(
+            it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
+              .AUTHORIZATION_REQUESTED,
+            ZonedDateTime.now())))
+
+    given(authorizationStateRetrieverService.getStateNpg(any(), any(), any(), any(), any()))
+      .willReturn(mono { npgStateResponse })
+    given(transactionsServiceClient.patchAuthRequest(any(), any()))
+      .willReturn(
+        mono { TransactionInfoDto().status(TransactionStatusDto.AUTHORIZATION_COMPLETED) })
+    /* test */
+    StepVerifier.create(
+        authorizationRequestedHelper.authorizationStateRetrieve(
+          Either.right(
+            QueueEvent(authorizationOutcomeWaitingEvent, TracingInfoTest.MOCK_TRACING_INFO)),
+          checkpointer))
+      .expectNext(Unit)
+      .verifyComplete()
+
+    /* Asserts */
+    verify(checkpointer, times(1)).success()
+    verify(authorizationStateRetrieverRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
+    verify(authorizationStateRetrieverService, times(1))
+      .getStateNpg(
+        transactionId,
+        expectedGetStateSessionId,
+        PSP_ID,
+        NPG_CORRELATION_ID,
+        NpgClient.PaymentMethod.CARDS)
+    verify(transactionsServiceClient, times(1))
+      .patchAuthRequest(transactionId, expectedPatchAuthRequest)
+  }
+
   @Test
   fun `messageReceiver consume event correctly and receive GDI_VERIFICATION outcome from NPG`() =
     runTest {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
 * forward `errorCode` from NPG when calling `getState`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR forwards the `errorCode` field from NPG's `getState` API to eCommerce's `PATCH auth-requests`.
This flow is invoked when NPG doesn't notify us of the payment's outcome so we have to fetch it manually.
Forwarding this field allows us to store it in case of errors during the authorization phase on the payment gateway.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.