### PR TITLE
[CHK-2918] fix: take NPG order id from authorization data when invoking `GET order/:orderId`

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/AuthorizationStateRetrieverService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/AuthorizationStateRetrieverService.kt
@@ -71,17 +71,19 @@ class AuthorizationStateRetrieverService(
         Mono.error(InvalidNPGPaymentGatewayException(trx.transactionId))
       }
       .flatMap { transaction ->
-        val activationData =
+        val orderId = transaction.transactionAuthorizationRequestData.authorizationRequestId
+        val correlationId =
           (transaction.transactionActivatedData.transactionGatewayActivationData
-            as NpgTransactionGatewayActivationData)
+              as NpgTransactionGatewayActivationData)
+            .correlationId
         performGetOrder(
           transactionId = trx.transactionId,
           pspId = transaction.transactionAuthorizationRequestData.pspId,
           paymentMethod =
             NpgClient.PaymentMethod.valueOf(
               transaction.transactionAuthorizationRequestData.paymentMethodName),
-          orderId = activationData.orderId,
-          correlationId = activationData.correlationId)
+          orderId = orderId,
+          correlationId = correlationId)
       }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
 * take NPG order id from authorization data when invoking `GET order/:orderId`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixes issue when invoking `GET /order/:orderId` with APMs (where `orderId` is not available upon activation but only on authorization request).
This fix is retrocompatible as in case of cards the activation's `orderId` is used as the `authorizationRequestId`.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.