### PR TITLE
[CHK-2796] fix: set correct time offset in redirect `closePayment` `additionalPaymentInformation`

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
@@ -25,6 +25,7 @@ import it.pagopa.ecommerce.eventdispatcher.utils.ConfidentialDataUtils
 import it.pagopa.ecommerce.eventdispatcher.utils.PaymentCode
 import it.pagopa.generated.ecommerce.nodo.v2.dto.*
 import java.math.BigDecimal
+import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -402,8 +403,10 @@ class NodeService(
             this.fee = feeEuro.toString()
             timestampOperation =
               OffsetDateTime.parse(
-                authCompleted.transactionAuthorizationCompletedData.timestampOperation,
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                  authCompleted.transactionAuthorizationCompletedData.timestampOperation,
+                  DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                .withOffsetSameInstant(ZoneId.of("Europe/Paris").rules.getOffset(Instant.now()))
+                .truncatedTo(ChronoUnit.SECONDS)
           }
         } else null
       transactionDetails = closePaymentTransactionDetails

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
@@ -21,7 +21,9 @@ import it.pagopa.ecommerce.eventdispatcher.utils.PaymentCode
 import it.pagopa.generated.ecommerce.nodo.v2.dto.*
 import it.pagopa.generated.ecommerce.nodo.v2.dto.CardAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum
 import java.math.BigDecimal
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -1182,6 +1184,7 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .withOffsetSameInstant(ZoneId.of("Europe/Paris").rules.getOffset(Instant.now()))
           .truncatedTo(ChronoUnit.SECONDS)
           .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
@@ -3472,6 +3475,7 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .withOffsetSameInstant(ZoneId.of("Europe/Paris").rules.getOffset(Instant.now()))
           .truncatedTo(ChronoUnit.SECONDS)
           .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
  * set correct time offset in redirect `closePayment` `additionalPaymentInformation`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes an invalid string representation for the `timestamp` inside `closePaymentBody` in the `additionalPaymentInformation` field for Checkout Redirect payments

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Local tests + deployed in env

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.