### PR TITLE
[CHK-2976] fix: set `additionalPaymentInformations` timestamps to naive date time format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
 						</goals>
 						<configuration>
 							<inputSpec>
-								https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
+								https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-2976-additionalpaymentinformation-redirect-timestamp/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
 							</inputSpec>
 							<generatorName>spring</generatorName>
 							<library>spring-cloud</library>

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
 						</goals>
 						<configuration>
 							<inputSpec>
-								https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-2976-additionalpaymentinformation-redirect-timestamp/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
+								https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
 							</inputSpec>
 							<generatorName>spring</generatorName>
 							<library>spring-cloud</library>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
@@ -402,8 +402,12 @@ class NodeService(
             this.fee = feeEuro.toString()
             timestampOperation =
               OffsetDateTime.parse(
-                authCompleted.transactionAuthorizationCompletedData.timestampOperation,
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                  authCompleted.transactionAuthorizationCompletedData.timestampOperation,
+                  DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                .atZoneSameInstant(ZoneId.of("Europe/Paris"))
+                .truncatedTo(ChronoUnit.SECONDS)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .toString()
           }
         } else null
       transactionDetails = closePaymentTransactionDetails
@@ -512,8 +516,12 @@ class NodeService(
             this.fee = feeEuro.toString()
             this.timestampOperation =
               OffsetDateTime.parse(
-                authCompleted.transactionAuthorizationCompletedData.timestampOperation,
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                  authCompleted.transactionAuthorizationCompletedData.timestampOperation,
+                  DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                .atZoneSameInstant(ZoneId.of("Europe/Paris"))
+                .truncatedTo(ChronoUnit.SECONDS)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .toString()
             this.totalAmount = totalAmountEuro.toString()
             this.email = it
           }
@@ -583,8 +591,12 @@ class NodeService(
             this.fee = feeEuro.toString()
             this.timestampOperation =
               OffsetDateTime.parse(
-                authCompleted.transactionAuthorizationCompletedData.timestampOperation,
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                  authCompleted.transactionAuthorizationCompletedData.timestampOperation,
+                  DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                .atZoneSameInstant(ZoneId.of("Europe/Paris"))
+                .truncatedTo(ChronoUnit.SECONDS)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .toString()
             this.authorizationCode = npgTransactionGatewayAuthorizationData.operationId
             this.email = it
           }
@@ -653,8 +665,12 @@ class NodeService(
             this.validationServiceId = npgTransactionGatewayAuthorizationData.validationServiceId
             this.timestampOperation =
               OffsetDateTime.parse(
-                authCompleted.transactionAuthorizationCompletedData.timestampOperation,
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                  authCompleted.transactionAuthorizationCompletedData.timestampOperation,
+                  DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                .atZoneSameInstant(ZoneId.of("Europe/Paris"))
+                .truncatedTo(ChronoUnit.SECONDS)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .toString()
             this.email = it
           }
         }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
@@ -22,6 +22,7 @@ import it.pagopa.generated.ecommerce.nodo.v2.dto.*
 import it.pagopa.generated.ecommerce.nodo.v2.dto.CardAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum
 import java.math.BigDecimal
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -1182,8 +1183,10 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+          .toString()
 
       val expected =
         RedirectClosePaymentRequestV2Dto().apply {
@@ -1239,7 +1242,7 @@ class NodeServiceTests {
             }
           additionalPaymentInformations =
             RedirectAdditionalPaymentInformationsDto().apply {
-              timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              timestampOperation = expectedTimestamp
               idPSPTransaction = authEvent.data.authorizationRequestId
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
@@ -1535,8 +1538,9 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         PayPalClosePaymentRequestV2Dto().apply {
@@ -1600,7 +1604,7 @@ class NodeServiceTests {
                 (authCompletedEvent.data.transactionGatewayAuthorizationData
                     as NpgTransactionGatewayAuthorizationData)
                   .paymentEndToEndId
-              timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              timestampOperation = expectedTimestamp
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
               this.email = EMAIL_STRING
@@ -1926,8 +1930,9 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         BancomatPayClosePaymentRequestV2Dto().apply {
@@ -1991,7 +1996,7 @@ class NodeServiceTests {
                 BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.OK
               this.totalAmount = totalAmountEuro.toString()
               this.fee = feeEuro.toString()
-              this.timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              this.timestampOperation = expectedTimestamp
               this.authorizationCode =
                 (authCompletedEvent.data.transactionGatewayAuthorizationData
                     as NpgTransactionGatewayAuthorizationData)
@@ -2320,7 +2325,8 @@ class NodeServiceTests {
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         MyBankClosePaymentRequestV2Dto().apply {
@@ -2387,7 +2393,7 @@ class NodeServiceTests {
               this.totalAmount = totalAmountEuro.toString()
               this.fee = feeEuro.toString()
               this.validationServiceId = NPG_VALIDATION_SERVICE_ID
-              this.timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              this.timestampOperation = expectedTimestamp
               this.email = EMAIL_STRING
             }
         }
@@ -3097,8 +3103,9 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         PayPalClosePaymentRequestV2Dto().apply {
@@ -3163,7 +3170,7 @@ class NodeServiceTests {
                 (authCompletedEvent.data.transactionGatewayAuthorizationData
                     as NpgTransactionGatewayAuthorizationData)
                   .paymentEndToEndId
-              timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              timestampOperation = expectedTimestamp
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
               this.email = EMAIL_STRING
@@ -3472,8 +3479,9 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         RedirectClosePaymentRequestV2Dto().apply {
@@ -3533,7 +3541,7 @@ class NodeServiceTests {
             }
           additionalPaymentInformations =
             RedirectAdditionalPaymentInformationsDto().apply {
-              timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              timestampOperation = expectedTimestamp
               idPSPTransaction = authEvent.data.authorizationRequestId
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
@@ -3834,8 +3842,9 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         PayPalClosePaymentRequestV2Dto().apply {
@@ -3903,7 +3912,7 @@ class NodeServiceTests {
                 (authCompletedEvent.data.transactionGatewayAuthorizationData
                     as NpgTransactionGatewayAuthorizationData)
                   .paymentEndToEndId
-              timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              timestampOperation = expectedTimestamp
               this.fee = feeEuro.toString()
               this.totalAmount = totalAmountEuro.toString()
               this.email = EMAIL_STRING
@@ -4235,8 +4244,9 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         BancomatPayClosePaymentRequestV2Dto().apply {
@@ -4304,7 +4314,7 @@ class NodeServiceTests {
                 BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.OK
               this.totalAmount = totalAmountEuro.toString()
               this.fee = feeEuro.toString()
-              this.timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              this.timestampOperation = expectedTimestamp
               this.authorizationCode =
                 (authCompletedEvent.data.transactionGatewayAuthorizationData
                     as NpgTransactionGatewayAuthorizationData)
@@ -4637,8 +4647,9 @@ class NodeServiceTests {
       val expectedTimestamp =
         OffsetDateTime.parse(
             authCompletedEvent.data.timestampOperation, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .atZoneSameInstant(ZoneId.of("Europe/Paris"))
           .truncatedTo(ChronoUnit.SECONDS)
-          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+          .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
       val expected =
         MyBankClosePaymentRequestV2Dto().apply {
@@ -4709,7 +4720,7 @@ class NodeServiceTests {
               this.totalAmount = totalAmountEuro.toString()
               this.fee = feeEuro.toString()
               this.validationServiceId = NPG_VALIDATION_SERVICE_ID
-              this.timestampOperation = OffsetDateTime.parse(expectedTimestamp)
+              this.timestampOperation = expectedTimestamp
               this.email = EMAIL_STRING
             }
         }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * changed timestamps populated inside `closePayment` `additionalPaymentInformation` like cards, now the populated timestamp is an ISO-8601 local date-time with `Europe/Rome`/`Europe/Paris` timezone

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Wrong date-time format broke the  flow after `closePayment`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Updated unit tests + tested with `pagopa-ecommerce-local`

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Depends on pagopa/pagopa-infra#2205