### PR TITLE
feat: [CHK-3007] - use bpayEndToEndId as paymentEndToEndId

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
@@ -583,7 +583,7 @@ class NodeService(
         .flatMap { email }
         .map {
           BancomatPayAdditionalPaymentInformationsDto().apply {
-            this.transactionId = npgTransactionGatewayAuthorizationData.operationId
+            this.transactionId = npgTransactionGatewayAuthorizationData.paymentEndToEndId
             this.outcomePaymentGateway =
               BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.valueOf(
                 transactionOutcome.name)

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
@@ -1982,7 +1982,7 @@ class NodeServiceTests {
             this.transactionId =
               (authCompletedEvent.data.transactionGatewayAuthorizationData
                   as NpgTransactionGatewayAuthorizationData)
-                .operationId
+                .paymentEndToEndId
             this.outcomePaymentGateway =
               BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.OK
             this.totalAmount = totalAmountEuro.toString()
@@ -4298,7 +4298,7 @@ class NodeServiceTests {
             this.transactionId =
               (authCompletedEvent.data.transactionGatewayAuthorizationData
                   as NpgTransactionGatewayAuthorizationData)
-                .operationId
+                .paymentEndToEndId
             this.outcomePaymentGateway =
               BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.OK
             this.totalAmount = totalAmountEuro.toString()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Use `bpayEndToEndId` as `paymentEndToEndId` for bancomat pay GET state
<!--- Describe your changes in detail -->

#### Motivation and Context
For bancomat pay the end to end id to be used for close payment to be used is `bpayEndToEndId`  
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.