### PR TITLE
[CHK-3008]-  Bancomat pay close payment

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
@@ -583,7 +583,7 @@ class NodeService(
         .flatMap { email }
         .map {
           BancomatPayAdditionalPaymentInformationsDto().apply {
-            this.transactionId = npgTransactionGatewayAuthorizationData.operationId
+            this.transactionId = npgTransactionGatewayAuthorizationData.paymentEndToEndId
             this.outcomePaymentGateway =
               BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.valueOf(
                 transactionOutcome.name)

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
@@ -1982,7 +1982,7 @@ class NodeServiceTests {
             this.transactionId =
               (authCompletedEvent.data.transactionGatewayAuthorizationData
                   as NpgTransactionGatewayAuthorizationData)
-                .operationId
+                .paymentEndToEndId
             this.outcomePaymentGateway =
               BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.OK
             this.totalAmount = totalAmountEuro.toString()
@@ -4298,7 +4298,7 @@ class NodeServiceTests {
             this.transactionId =
               (authCompletedEvent.data.transactionGatewayAuthorizationData
                   as NpgTransactionGatewayAuthorizationData)
-                .operationId
+                .paymentEndToEndId
             this.outcomePaymentGateway =
               BancomatPayAdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.OK
             this.totalAmount = totalAmountEuro.toString()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Change `additionalPaymentInformations.transactionId` close payment field in order to be valued with the received `bpayEndToEndId` received by NPG
<!--- Describe your changes in detail -->

#### Motivation and Context
For PSP to correctly reconciliate transaction the `bpayEndToEndId` field have to be used as additionalPaymentInformations.transactionId field into close payment request performed with Bancomat Pay payment method. This field is stored into eCommerce event store as paymentEndToEndId and is then used to populate close payment request
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.