### PR TITLE
[CHK-3011] mybank get state

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -35,6 +35,7 @@ import it.pagopa.ecommerce.eventdispatcher.services.eventretry.v2.RefundRetrySer
 import it.pagopa.ecommerce.eventdispatcher.services.v2.AuthorizationStateRetrieverService
 import it.pagopa.ecommerce.eventdispatcher.services.v2.NpgService
 import it.pagopa.ecommerce.eventdispatcher.utils.DeadLetterTracedQueueAsyncClient
+import it.pagopa.ecommerce.eventdispatcher.utils.EndToEndId
 import it.pagopa.generated.ecommerce.gateway.v1.dto.VposDeleteResponseDto
 import it.pagopa.generated.ecommerce.gateway.v1.dto.VposDeleteResponseDto.StatusEnum
 import it.pagopa.generated.ecommerce.gateway.v1.dto.XPayRefundResponse200Dto
@@ -54,8 +55,6 @@ import reactor.kotlin.core.publisher.toMono
 object QueueCommonsLogger {
   val logger: Logger = LoggerFactory.getLogger(QueueCommonsLogger::class.java)
 }
-
-const val BANCOMAT_PAY_END_TO_END_ID = "bpayEndToEndId"
 
 fun updateTransactionToExpired(
   transaction: BaseTransaction,
@@ -363,7 +362,9 @@ fun getPaymentEndToEndId(operationDto: OperationDto): String? =
     // for bancomatPay we expect an `bpayEndToEndId` entry into additional data map to be used as
     // the paymentEndToEndId
     NpgClient.PaymentMethod.BANCOMATPAY.serviceName ->
-      operationDto.additionalData?.get(BANCOMAT_PAY_END_TO_END_ID) as String?
+      operationDto.additionalData?.get(EndToEndId.BANCOMAT_PAY.value) as String?
+    NpgClient.PaymentMethod.MYBANK.serviceName ->
+      operationDto.additionalData?.get(EndToEndId.MYBANK.value) as String?
     else -> operationDto.paymentEndToEndId
   }
 

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeService.kt
@@ -658,7 +658,7 @@ class NodeService(
         .flatMap { email }
         .map {
           MyBankAdditionalPaymentInformationsDto().apply {
-            this.transactionId = npgTransactionGatewayAuthorizationData.operationId
+            this.transactionId = authCompleted.transactionId.value()
             this.myBankTransactionId = npgTransactionGatewayAuthorizationData.paymentEndToEndId
             this.totalAmount = totalAmountEuro.toString()
             this.fee = feeEuro.toString()

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/EndToEndId.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/EndToEndId.kt
@@ -2,5 +2,5 @@ package it.pagopa.ecommerce.eventdispatcher.utils
 
 enum class EndToEndId(val value: String) {
   BANCOMAT_PAY("bpayEndToEndId"),
-  MYBANK("mybankEndToEndId")
+  MYBANK("myBankEndToEndId")
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/EndToEndId.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/EndToEndId.kt
@@ -1,0 +1,6 @@
+package it.pagopa.ecommerce.eventdispatcher.utils
+
+enum class EndToEndId(val value: String) {
+  BANCOMAT_PAY("bpayEndToEndId"),
+  MYBANK("mybankEndToEndId")
+}

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
@@ -1810,7 +1810,7 @@ class AuhtorizationRequestedHelperTests {
   @ParameterizedTest
   @MethodSource(
     "messageReceiver consume event correctly and perform PATCH auth request for PaymentMethod payment circuit")
-  fun `messageReceiver consume event correctly and perform PATCH auth request for PaymentMethod payment circuit`(
+  fun `messageReceiver consume event correctly and perform PATCH auth request for apm payment circuit retrieving paymentEndToEndId from NPG additionalData`(
     endToEndId: EndToEndId,
     paymentMethod: NpgClient.PaymentMethod
   ) = runTest {

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuhtorizationRequestedHelperTests.kt
@@ -26,6 +26,7 @@ import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsViewReposito
 import it.pagopa.ecommerce.eventdispatcher.services.eventretry.v2.AuthorizationStateRetrieverRetryService
 import it.pagopa.ecommerce.eventdispatcher.services.v2.AuthorizationStateRetrieverService
 import it.pagopa.ecommerce.eventdispatcher.utils.DeadLetterTracedQueueAsyncClient
+import it.pagopa.ecommerce.eventdispatcher.utils.EndToEndId
 import it.pagopa.generated.transactionauthrequests.v1.dto.OutcomeNpgGatewayDto
 import it.pagopa.generated.transactionauthrequests.v1.dto.TransactionInfoDto
 import it.pagopa.generated.transactionauthrequests.v1.dto.TransactionStatusDto
@@ -115,6 +116,13 @@ class AuhtorizationRequestedHelperTests {
     @JvmStatic
     fun `Patch auth request transaction service exception 5xx method source`(): Stream<Arguments> =
       Stream.of(Arguments.of(GatewayTimeoutException()), Arguments.of(BadGatewayException("test")))
+
+    @JvmStatic
+    fun `messageReceiver consume event correctly and perform PATCH auth request for PaymentMethod payment circuit`():
+      Stream<Arguments> =
+      Stream.of(
+        Arguments.of(EndToEndId.BANCOMAT_PAY, NpgClient.PaymentMethod.BANCOMATPAY),
+        Arguments.of(EndToEndId.MYBANK, NpgClient.PaymentMethod.MYBANK))
   }
 
   @ParameterizedTest
@@ -1799,104 +1807,107 @@ class AuhtorizationRequestedHelperTests {
       .enqueueRetryEvent(any(), any(), any(), anyOrNull())
   }
 
-  @Test
-  fun `messageReceiver consume event correctly and perform PATCH auth request for Bancomat pay payment circuit`() =
-    runTest {
-      val activatedEvent = transactionActivateEvent(npgTransactionGatewayActivationData())
-      val authorizationRequestedEvent =
-        transactionAuthorizationRequestedEvent(
-          TransactionAuthorizationRequestData.PaymentGateway.NPG,
-          npgTransactionGatewayAuthorizationRequestedData())
+  @ParameterizedTest
+  @MethodSource(
+    "messageReceiver consume event correctly and perform PATCH auth request for PaymentMethod payment circuit")
+  fun `messageReceiver consume event correctly and perform PATCH auth request for PaymentMethod payment circuit`(
+    endToEndId: EndToEndId,
+    paymentMethod: NpgClient.PaymentMethod
+  ) = runTest {
+    val activatedEvent = transactionActivateEvent(npgTransactionGatewayActivationData())
+    val authorizationRequestedEvent =
+      transactionAuthorizationRequestedEvent(
+        TransactionAuthorizationRequestData.PaymentGateway.NPG,
+        npgTransactionGatewayAuthorizationRequestedData())
 
-      val authorizationOutcomeWaitingEvent = transactionAuthorizationOutcomeWaitingEvent(1)
-      val transactionId = TransactionId(TRANSACTION_ID)
-      val operationId = "operationId"
-      val orderId = "orderId"
-      val bpayEndToEndId = "bpayEndToEndId"
-      val paymentEndToEndId = "paymentEndToEndId"
-      val npgStateResponse =
-        StateResponseDto()
-          .state(WorkflowStateDto.PAYMENT_COMPLETE)
-          .operation(
-            OperationDto()
-              .operationId(operationId)
-              .orderId(orderId)
-              .operationResult(OperationResultDto.EXECUTED)
-              .paymentEndToEndId(paymentEndToEndId)
-              .operationTime("2024-01-01T00:00:00")
-              .paymentCircuit("BANCOMATPAY")
-              .additionalData(mapOf("bpayEndToEndId" to bpayEndToEndId)))
-      val expectedGetStateSessionId = NPG_CONFIRM_PAYMENT_SESSION_ID
-      val expectedPatchAuthRequest =
-        UpdateAuthorizationRequestDto().apply {
-          outcomeGateway =
-            OutcomeNpgGatewayDto().apply {
-              this.paymentGatewayType = "NPG"
-              this.operationResult = OutcomeNpgGatewayDto.OperationResultEnum.EXECUTED
-              this.orderId = orderId
-              this.operationId = operationId
-              this.authorizationCode = null
-              this.paymentEndToEndId = bpayEndToEndId
-              this.rrn = null
-            }
-          timestampOperation = OffsetDateTime.parse("2024-01-01T00:00:00+01:00")
-        }
-
-      /* preconditions */
-      given(checkpointer.success()).willReturn(Mono.empty())
-      given(
-          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
-            any(),
-          ))
-        .willReturn(
-          Flux.just(
-            activatedEvent as TransactionEvent<Any>,
-            authorizationRequestedEvent as TransactionEvent<Any>,
-            authorizationOutcomeWaitingEvent as TransactionEvent<Any>,
-          ))
-
-      given(transactionsViewRepository.save(transactionViewRepositoryCaptor.capture())).willAnswer {
-        Mono.just(it.arguments[0])
+    val authorizationOutcomeWaitingEvent = transactionAuthorizationOutcomeWaitingEvent(1)
+    val transactionId = TransactionId(TRANSACTION_ID)
+    val operationId = "operationId"
+    val orderId = "orderId"
+    val paymentEndToEndId = "paymentEndToEndId"
+    val npgStateResponse =
+      StateResponseDto()
+        .state(WorkflowStateDto.PAYMENT_COMPLETE)
+        .operation(
+          OperationDto()
+            .operationId(operationId)
+            .orderId(orderId)
+            .operationResult(OperationResultDto.EXECUTED)
+            .paymentEndToEndId(paymentEndToEndId)
+            .operationTime("2024-01-01T00:00:00")
+            .paymentCircuit(paymentMethod.name)
+            .additionalData(mapOf(endToEndId.value to endToEndId.value)))
+    val expectedGetStateSessionId = NPG_CONFIRM_PAYMENT_SESSION_ID
+    val expectedPatchAuthRequest =
+      UpdateAuthorizationRequestDto().apply {
+        outcomeGateway =
+          OutcomeNpgGatewayDto().apply {
+            this.paymentGatewayType = "NPG"
+            this.operationResult = OutcomeNpgGatewayDto.OperationResultEnum.EXECUTED
+            this.orderId = orderId
+            this.operationId = operationId
+            this.authorizationCode = null
+            this.paymentEndToEndId = endToEndId.value
+            this.rrn = null
+          }
+        timestampOperation = OffsetDateTime.parse("2024-01-01T00:00:00+01:00")
       }
 
-      given(
-          authorizationStateRetrieverRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), any()))
-        .willReturn(Mono.empty())
-      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
-        .willReturn(
-          Mono.just(
-            transactionDocument(
-              it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
-                .AUTHORIZATION_REQUESTED,
-              ZonedDateTime.now())))
+    /* preconditions */
+    given(checkpointer.success()).willReturn(Mono.empty())
+    given(
+        transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
+          any(),
+        ))
+      .willReturn(
+        Flux.just(
+          activatedEvent as TransactionEvent<Any>,
+          authorizationRequestedEvent as TransactionEvent<Any>,
+          authorizationOutcomeWaitingEvent as TransactionEvent<Any>,
+        ))
 
-      given(authorizationStateRetrieverService.getStateNpg(any(), any(), any(), any(), any()))
-        .willReturn(mono { npgStateResponse })
-      given(transactionsServiceClient.patchAuthRequest(any(), any()))
-        .willReturn(
-          mono { TransactionInfoDto().status(TransactionStatusDto.AUTHORIZATION_COMPLETED) })
-      /* test */
-      StepVerifier.create(
-          authorizationRequestedHelper.authorizationStateRetrieve(
-            Either.right(
-              QueueEvent(authorizationOutcomeWaitingEvent, TracingInfoTest.MOCK_TRACING_INFO)),
-            checkpointer))
-        .expectNext(Unit)
-        .verifyComplete()
-
-      /* Asserts */
-      verify(checkpointer, times(1)).success()
-      verify(authorizationStateRetrieverRetryService, times(0))
-        .enqueueRetryEvent(any(), any(), any(), anyOrNull())
-      verify(authorizationStateRetrieverService, times(1))
-        .getStateNpg(
-          transactionId,
-          expectedGetStateSessionId,
-          PSP_ID,
-          NPG_CORRELATION_ID,
-          NpgClient.PaymentMethod.CARDS)
-      verify(transactionsServiceClient, times(1))
-        .patchAuthRequest(transactionId, expectedPatchAuthRequest)
+    given(transactionsViewRepository.save(transactionViewRepositoryCaptor.capture())).willAnswer {
+      Mono.just(it.arguments[0])
     }
+
+    given(
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), retryCountCaptor.capture(), any(), any()))
+      .willReturn(Mono.empty())
+    given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
+      .willReturn(
+        Mono.just(
+          transactionDocument(
+            it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
+              .AUTHORIZATION_REQUESTED,
+            ZonedDateTime.now())))
+
+    given(authorizationStateRetrieverService.getStateNpg(any(), any(), any(), any(), any()))
+      .willReturn(mono { npgStateResponse })
+    given(transactionsServiceClient.patchAuthRequest(any(), any()))
+      .willReturn(
+        mono { TransactionInfoDto().status(TransactionStatusDto.AUTHORIZATION_COMPLETED) })
+    /* test */
+    StepVerifier.create(
+        authorizationRequestedHelper.authorizationStateRetrieve(
+          Either.right(
+            QueueEvent(authorizationOutcomeWaitingEvent, TracingInfoTest.MOCK_TRACING_INFO)),
+          checkpointer))
+      .expectNext(Unit)
+      .verifyComplete()
+
+    /* Asserts */
+    verify(checkpointer, times(1)).success()
+    verify(authorizationStateRetrieverRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(authorizationStateRetrieverService, times(1))
+      .getStateNpg(
+        transactionId,
+        expectedGetStateSessionId,
+        PSP_ID,
+        NPG_CORRELATION_ID,
+        NpgClient.PaymentMethod.CARDS)
+    verify(transactionsServiceClient, times(1))
+      .patchAuthRequest(transactionId, expectedPatchAuthRequest)
+  }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/NodeServiceTests.kt
@@ -2372,10 +2372,7 @@ class NodeServiceTests {
           }
         additionalPaymentInformations =
           MyBankAdditionalPaymentInformationsDto().apply {
-            this.transactionId =
-              (authCompletedEvent.data.transactionGatewayAuthorizationData
-                  as NpgTransactionGatewayAuthorizationData)
-                .operationId
+            this.transactionId = authCompletedEvent.transactionId
             this.myBankTransactionId =
               (authCompletedEvent.data.transactionGatewayAuthorizationData
                   as NpgTransactionGatewayAuthorizationData)
@@ -4698,10 +4695,7 @@ class NodeServiceTests {
           }
         additionalPaymentInformations =
           MyBankAdditionalPaymentInformationsDto().apply {
-            this.transactionId =
-              (authCompletedEvent.data.transactionGatewayAuthorizationData
-                  as NpgTransactionGatewayAuthorizationData)
-                .operationId
+            this.transactionId = authCompletedEvent.transactionId
             this.myBankTransactionId =
               (authCompletedEvent.data.transactionGatewayAuthorizationData
                   as NpgTransactionGatewayAuthorizationData)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Update GET state logic for MyBank performed transactions: use `myBankEndToEndId` as paymentEndToEndId field into transactions-service PATCH auth request
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to properly retrieve payment end to end id for MyBank transactions and use the newly added NPG `myBankEndToEndId` field
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.