### PR TITLE
feat: trace close payment requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,7 +590,7 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
-					<scmVersionType>branch</scmVersionType>
+					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>1.22.0</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>1.23.0</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**,
 			**/it/pagopa/ecommerce/eventdispatcher/validation/**
@@ -591,8 +591,6 @@
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
 					<scmVersionType>branch</scmVersionType>
-					<scmVersion>CHK-3057-update-transaction-utils</scmVersion>
-					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>1.21.0</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>1.22.0</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**,
 			**/it/pagopa/ecommerce/eventdispatcher/validation/**
@@ -590,6 +590,8 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+					<scmVersion>CHK-3057-update-transaction-utils</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/config/OpenTelemetryConfig.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/config/OpenTelemetryConfig.kt
@@ -4,6 +4,8 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 import it.pagopa.ecommerce.commons.queues.TracingUtils
+import it.pagopa.ecommerce.commons.utils.OpenTelemetryUtils
+import it.pagopa.ecommerce.commons.utils.UpdateTransactionStatusTracerUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -18,4 +20,10 @@ class OpenTelemetryConfig {
   @Bean
   fun tracingUtils(openTelemetry: OpenTelemetry, tracer: Tracer): TracingUtils =
     TracingUtils(openTelemetry, tracer)
+
+  @Bean
+  fun updateTransactionStatusTracerUtils(
+    openTelemetryTracer: Tracer
+  ): UpdateTransactionStatusTracerUtils =
+    UpdateTransactionStatusTracerUtils(OpenTelemetryUtils(openTelemetryTracer))
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -297,7 +297,7 @@ class ClosePaymentHelper(
               nodeResult =
                 UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
                   ClosePaymentOutcome.KO.toString(),
-                  Optional.of("HTTP error code: [$statusCode], description: [$errorDescription]"),
+                  Optional.of("$statusCode - [$errorDescription]"),
                 ),
               updateTransactionStatusOutcome = UpdateTransactionStatusOutcome.PROCESSING_ERROR)
           }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -6,6 +6,7 @@ import it.pagopa.ecommerce.commons.client.QueueAsyncClient
 import it.pagopa.ecommerce.commons.documents.v2.*
 import it.pagopa.ecommerce.commons.documents.v2.Transaction
 import it.pagopa.ecommerce.commons.documents.v2.authorization.NpgTransactionGatewayAuthorizationData
+import it.pagopa.ecommerce.commons.documents.v2.authorization.NpgTransactionGatewayAuthorizationRequestedData
 import it.pagopa.ecommerce.commons.documents.v2.authorization.PgsTransactionGatewayAuthorizationData
 import it.pagopa.ecommerce.commons.documents.v2.authorization.RedirectTransactionGatewayAuthorizationData
 import it.pagopa.ecommerce.commons.domain.v2.*
@@ -18,6 +19,9 @@ import it.pagopa.ecommerce.commons.queues.StrictJsonSerializerProvider
 import it.pagopa.ecommerce.commons.queues.TracingInfo
 import it.pagopa.ecommerce.commons.queues.TracingUtils
 import it.pagopa.ecommerce.commons.redis.templatewrappers.PaymentRequestInfoRedisTemplateWrapper
+import it.pagopa.ecommerce.commons.utils.UpdateTransactionStatusTracerUtils
+import it.pagopa.ecommerce.commons.utils.UpdateTransactionStatusTracerUtils.UpdateTransactionStatusOutcome
+import it.pagopa.ecommerce.commons.utils.UpdateTransactionStatusTracerUtils.UserCancelClosePaymentNodoStatusUpdate
 import it.pagopa.ecommerce.eventdispatcher.client.NodeClient
 import it.pagopa.ecommerce.eventdispatcher.exceptions.BadTransactionStatusException
 import it.pagopa.ecommerce.eventdispatcher.exceptions.ClosePaymentErrorResponseException
@@ -128,6 +132,7 @@ class ClosePaymentHelper(
   @Autowired private val refundQueueAsyncClient: QueueAsyncClient,
   @Value("\${azurestorage.queues.transientQueues.ttlSeconds}")
   private val transientQueueTTLSeconds: Int,
+  @Autowired private val updateTransactionStatusTracerUtils: UpdateTransactionStatusTracerUtils
 ) {
   val logger: Logger = LoggerFactory.getLogger(ClosePaymentHelper::class.java)
 
@@ -218,7 +223,8 @@ class ClosePaymentHelper(
                 exception = it,
                 baseTransaction = baseTransaction,
                 retryCount = retryCount,
-                tracingInfo = tracingInfo)
+                tracingInfo = tracingInfo,
+                closePaymentTransactionData = closePaymentTransactionData)
             }
         }
         .then()
@@ -239,6 +245,7 @@ class ClosePaymentHelper(
     baseTransaction: Mono<BaseTransaction>,
     retryCount: Int,
     tracingInfo: TracingInfo,
+    closePaymentTransactionData: ClosePaymentTransactionData
   ) =
     baseTransaction
       .publishOn(Schedulers.boundedElastic())
@@ -246,6 +253,7 @@ class ClosePaymentHelper(
         logger.error(
           "Got exception while processing closePaymentV2 for transaction with id ${tx.transactionId.value()}!",
           exception)
+
         updateTransactionToClosureError(tx)
       }
       .flatMap { tx ->
@@ -272,16 +280,27 @@ class ClosePaymentHelper(
           refundTransaction,
           enqueueRetryEvent)
         if (refundTransaction) {
-          requestRefundTransactionPipeline(tx, TransactionClosureData.Outcome.KO, tracingInfo)
-            .then()
-        } else {
-          if (enqueueRetryEvent) {
-            enqueueClosureRetryEventPipeline(
-              baseTransaction = tx, retryCount = retryCount, tracingInfo = tracingInfo)
+            requestRefundTransactionPipeline(tx, TransactionClosureData.Outcome.KO, tracingInfo)
+              .then()
           } else {
-            Mono.empty()
+            if (enqueueRetryEvent) {
+              enqueueClosureRetryEventPipeline(
+                baseTransaction = tx, retryCount = retryCount, tracingInfo = tracingInfo)
+            } else {
+              Mono.empty()
+            }
           }
-        }
+          .doAfterTerminate {
+            traceClosePaymentUpdateStatus(
+              baseTransaction = tx,
+              closePaymentTransactionData = closePaymentTransactionData,
+              nodeResult =
+                UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
+                  ClosePaymentOutcome.KO.toString(),
+                  Optional.of("HTTP error code: [$statusCode], description: [$errorDescription]"),
+                ),
+              updateTransactionStatusOutcome = UpdateTransactionStatusOutcome.PROCESSING_ERROR)
+          }
       }
 
   private fun enqueueClosureRetryEventPipeline(
@@ -402,9 +421,19 @@ class ClosePaymentHelper(
           }
         })
 
-    return saveEvent.fold(
-      { it.map { closureFailed -> Either.left(closureFailed) } },
-      { it.map { closed -> Either.right(closed) } })
+    return saveEvent
+      .fold<Mono<Either<TransactionClosureFailedEvent, TransactionClosedEvent>>>(
+        { it.map { closureFailed -> Either.left(closureFailed) } },
+        { it.map { closed -> Either.right(closed) } })
+      .doOnSuccess {
+        traceClosePaymentUpdateStatus(
+          baseTransaction = transaction,
+          closePaymentTransactionData = closePaymentTransactionData,
+          nodeResult =
+            UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
+              outcome.toString(), Optional.empty()),
+          updateTransactionStatusOutcome = UpdateTransactionStatusOutcome.OK)
+      }
   }
 
   private fun wasTransactionCanceledByUser(
@@ -581,5 +610,44 @@ class ClosePaymentHelper(
 
   private fun getRetryCount(event: ClosePaymentEvent): Int {
     return event.fold({ 0 }, { 0 }, { it.event.data.retryCount }, { 0 })
+  }
+
+  private fun traceClosePaymentUpdateStatus(
+    baseTransaction: BaseTransaction,
+    closePaymentTransactionData: ClosePaymentTransactionData,
+    nodeResult: UpdateTransactionStatusTracerUtils.GatewayOutcomeResult,
+    updateTransactionStatusOutcome: UpdateTransactionStatusOutcome
+  ) {
+    val statusUpdateInfo =
+      if (closePaymentTransactionData.canceledByUser) {
+        UserCancelClosePaymentNodoStatusUpdate(
+          updateTransactionStatusOutcome, baseTransaction.clientId, nodeResult)
+      } else {
+        val baseTransactionWithRequestedAuthorization =
+          baseTransaction.let {
+            if (it is BaseTransactionWithClosureError) {
+              it.transactionAtPreviousState
+            } else {
+              it
+            }
+            // safe cast here: close payment is performed for user canceled transactions or
+            // transactions for which have been requested authorization
+          } as BaseTransactionWithRequestedAuthorization
+        UpdateTransactionStatusTracerUtils.ClosePaymentNodoStatusUpdate(
+          updateTransactionStatusOutcome,
+          baseTransactionWithRequestedAuthorization.transactionAuthorizationRequestData.pspId,
+          baseTransactionWithRequestedAuthorization.transactionAuthorizationRequestData
+            .paymentTypeCode,
+          baseTransactionWithRequestedAuthorization.clientId,
+          Optional.of(
+              baseTransactionWithRequestedAuthorization.transactionAuthorizationRequestData
+                .transactionGatewayAuthorizationRequestedData)
+            .filter { it is NpgTransactionGatewayAuthorizationRequestedData }
+            .map { it as NpgTransactionGatewayAuthorizationRequestedData }
+            .map { it.walletInfo != null }
+            .orElse(false),
+          nodeResult)
+      }
+    updateTransactionStatusTracerUtils.traceStatusUpdateOperation(statusUpdateInfo)
   }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
@@ -848,8 +848,7 @@ class ClosePaymentHelperTests {
             Transaction.ClientId.CHECKOUT,
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(),
-              Optional.of("HTTP error code: [null], description: [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
     }
 
   @Test
@@ -956,8 +955,7 @@ class ClosePaymentHelperTests {
           Transaction.ClientId.CHECKOUT,
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-            ClosePaymentOutcome.KO.toString(),
-            Optional.of("HTTP error code: [null], description: [null]"))))
+            ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
   }
 
   @Test
@@ -1061,8 +1059,7 @@ class ClosePaymentHelperTests {
           Transaction.ClientId.CHECKOUT,
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-            ClosePaymentOutcome.KO.toString(),
-            Optional.of("HTTP error code: [null], description: [null]"))))
+            ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
   }
 
   @Test
@@ -1174,8 +1171,7 @@ class ClosePaymentHelperTests {
             Transaction.ClientId.CHECKOUT,
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(),
-              Optional.of("HTTP error code: [null], description: [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
     }
 
   @Test
@@ -1390,8 +1386,7 @@ class ClosePaymentHelperTests {
           UpdateTransactionStatusTracerUtils.UpdateTransactionStatusOutcome.PROCESSING_ERROR,
           Transaction.ClientId.CHECKOUT,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-            ClosePaymentOutcome.KO.toString(),
-            Optional.of("HTTP error code: [null], description: [null]"))))
+            ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
   }
 
   @Test
@@ -1468,8 +1463,7 @@ class ClosePaymentHelperTests {
             UpdateTransactionStatusTracerUtils.UpdateTransactionStatusOutcome.PROCESSING_ERROR,
             Transaction.ClientId.CHECKOUT,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(),
-              Optional.of("HTTP error code: [400 BAD_REQUEST], description: [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("400 BAD_REQUEST - [null]"))))
     }
 
   @Test
@@ -1542,8 +1536,7 @@ class ClosePaymentHelperTests {
             UpdateTransactionStatusTracerUtils.UpdateTransactionStatusOutcome.PROCESSING_ERROR,
             Transaction.ClientId.CHECKOUT,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(),
-              Optional.of("HTTP error code: [400 BAD_REQUEST], description: [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("400 BAD_REQUEST - [null]"))))
     }
 
   @Test
@@ -1836,8 +1829,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of(
-                "HTTP error code: [422 UNPROCESSABLE_ENTITY], description: [Node did not receive RPT yet]"))))
+              Optional.of("422 UNPROCESSABLE_ENTITY - [Node did not receive RPT yet]"))))
     }
 
   @Test
@@ -1930,8 +1922,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of(
-                "HTTP error code: [422 UNPROCESSABLE_ENTITY], description: [unknown error]"))))
+              Optional.of("422 UNPROCESSABLE_ENTITY - [unknown error]"))))
     }
 
   @Test
@@ -2032,8 +2023,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of(
-                "HTTP error code: [422 UNPROCESSABLE_ENTITY], description: [unknown error]"))))
+              Optional.of("422 UNPROCESSABLE_ENTITY - [unknown error]"))))
     }
 
   @Test
@@ -2126,7 +2116,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("HTTP error code: [400 BAD_REQUEST], description: [bad request error]"))))
+              Optional.of("400 BAD_REQUEST - [bad request error]"))))
     }
 
   companion object {
@@ -2231,8 +2221,7 @@ class ClosePaymentHelperTests {
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
             ClosePaymentOutcome.KO.toString(),
-            Optional.of(
-              "HTTP error code: [$expectedHttpErrorCode], description: [$expectedErrorDescription]"))))
+            Optional.of("$expectedHttpErrorCode - [$expectedErrorDescription]"))))
   }
 
   @Test
@@ -2355,8 +2344,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of(
-                "HTTP error code: [422 UNPROCESSABLE_ENTITY], description: [Node did not receive RPT yet]"))))
+              Optional.of("422 UNPROCESSABLE_ENTITY - [Node did not receive RPT yet]"))))
     }
 
   @Test
@@ -2458,8 +2446,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of(
-                "HTTP error code: [422 UNPROCESSABLE_ENTITY], description: [unknown error]"))))
+              Optional.of("422 UNPROCESSABLE_ENTITY - [unknown error]"))))
     }
 
   @Test
@@ -2560,7 +2547,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("HTTP error code: [400 BAD_REQUEST], description: [bad request error]"))))
+              Optional.of("400 BAD_REQUEST - [bad request error]"))))
     }
 
   @ParameterizedTest
@@ -2661,8 +2648,7 @@ class ClosePaymentHelperTests {
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
             ClosePaymentOutcome.KO.toString(),
-            Optional.of(
-              "HTTP error code: [$expectedHttpErrorCode], description: [$expectedErrorDescription]"))))
+            Optional.of("$expectedHttpErrorCode - [$expectedErrorDescription]"))))
   }
 
   @Test

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
@@ -848,7 +848,7 @@ class ClosePaymentHelperTests {
             Transaction.ClientId.CHECKOUT,
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("HTTP code:[N/A] - descr:[N/A]"))))
     }
 
   @Test
@@ -955,7 +955,7 @@ class ClosePaymentHelperTests {
           Transaction.ClientId.CHECKOUT,
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-            ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
+            ClosePaymentOutcome.KO.toString(), Optional.of("HTTP code:[N/A] - descr:[N/A]"))))
   }
 
   @Test
@@ -1059,7 +1059,7 @@ class ClosePaymentHelperTests {
           Transaction.ClientId.CHECKOUT,
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-            ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
+            ClosePaymentOutcome.KO.toString(), Optional.of("HTTP code:[N/A] - descr:[N/A]"))))
   }
 
   @Test
@@ -1171,7 +1171,7 @@ class ClosePaymentHelperTests {
             Transaction.ClientId.CHECKOUT,
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("HTTP code:[N/A] - descr:[N/A]"))))
     }
 
   @Test
@@ -1386,7 +1386,7 @@ class ClosePaymentHelperTests {
           UpdateTransactionStatusTracerUtils.UpdateTransactionStatusOutcome.PROCESSING_ERROR,
           Transaction.ClientId.CHECKOUT,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-            ClosePaymentOutcome.KO.toString(), Optional.of("null - [null]"))))
+            ClosePaymentOutcome.KO.toString(), Optional.of("HTTP code:[N/A] - descr:[N/A]"))))
   }
 
   @Test
@@ -1463,7 +1463,7 @@ class ClosePaymentHelperTests {
             UpdateTransactionStatusTracerUtils.UpdateTransactionStatusOutcome.PROCESSING_ERROR,
             Transaction.ClientId.CHECKOUT,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(), Optional.of("400 BAD_REQUEST - [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("HTTP code:[400] - descr:[N/A]"))))
     }
 
   @Test
@@ -1536,7 +1536,7 @@ class ClosePaymentHelperTests {
             UpdateTransactionStatusTracerUtils.UpdateTransactionStatusOutcome.PROCESSING_ERROR,
             Transaction.ClientId.CHECKOUT,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
-              ClosePaymentOutcome.KO.toString(), Optional.of("400 BAD_REQUEST - [null]"))))
+              ClosePaymentOutcome.KO.toString(), Optional.of("HTTP code:[400] - descr:[N/A]"))))
     }
 
   @Test
@@ -1829,7 +1829,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("422 UNPROCESSABLE_ENTITY - [Node did not receive RPT yet]"))))
+              Optional.of("HTTP code:[422] - descr:[Node did not receive RPT yet]"))))
     }
 
   @Test
@@ -1922,7 +1922,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("422 UNPROCESSABLE_ENTITY - [unknown error]"))))
+              Optional.of("HTTP code:[422] - descr:[unknown error]"))))
     }
 
   @Test
@@ -2023,7 +2023,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("422 UNPROCESSABLE_ENTITY - [unknown error]"))))
+              Optional.of("HTTP code:[422] - descr:[unknown error]"))))
     }
 
   @Test
@@ -2116,7 +2116,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("400 BAD_REQUEST - [bad request error]"))))
+              Optional.of("HTTP code:[400] - descr:[bad request error]"))))
     }
 
   companion object {
@@ -2155,9 +2155,9 @@ class ClosePaymentHelperTests {
         closureErrorEvent)
     val (expectedHttpErrorCode, expectedErrorDescription) =
       if (throwable is ClosePaymentErrorResponseException) {
-        Pair(throwable.statusCode, throwable.errorResponse?.description)
+        Pair(throwable.statusCode?.value() ?: "N/A", throwable.errorResponse?.description ?: "N/A")
       } else {
-        Pair(null, null)
+        Pair("N/A", "N/A")
       }
     /* preconditions */
     given(checkpointer.success()).willReturn(Mono.empty())
@@ -2221,7 +2221,7 @@ class ClosePaymentHelperTests {
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
             ClosePaymentOutcome.KO.toString(),
-            Optional.of("$expectedHttpErrorCode - [$expectedErrorDescription]"))))
+            Optional.of("HTTP code:[$expectedHttpErrorCode] - descr:[$expectedErrorDescription]"))))
   }
 
   @Test
@@ -2344,7 +2344,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("422 UNPROCESSABLE_ENTITY - [Node did not receive RPT yet]"))))
+              Optional.of("HTTP code:[422] - descr:[Node did not receive RPT yet]"))))
     }
 
   @Test
@@ -2446,7 +2446,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("422 UNPROCESSABLE_ENTITY - [unknown error]"))))
+              Optional.of("HTTP code:[422] - descr:[unknown error]"))))
     }
 
   @Test
@@ -2547,7 +2547,7 @@ class ClosePaymentHelperTests {
             false,
             UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
               ClosePaymentOutcome.KO.toString(),
-              Optional.of("400 BAD_REQUEST - [bad request error]"))))
+              Optional.of("HTTP code:[400] - descr:[bad request error]"))))
     }
 
   @ParameterizedTest
@@ -2605,9 +2605,9 @@ class ClosePaymentHelperTests {
       .willReturn(Mono.empty())
     val (expectedHttpErrorCode, expectedErrorDescription) =
       if (throwable is ClosePaymentErrorResponseException) {
-        Pair(throwable.statusCode, throwable.errorResponse?.description)
+        Pair(throwable.statusCode?.value() ?: "N/A", throwable.errorResponse?.description ?: "N/A")
       } else {
-        Pair(null, null)
+        Pair("N/A", "N/A")
       }
     /* test */
     Hooks.onOperatorDebug()
@@ -2648,7 +2648,7 @@ class ClosePaymentHelperTests {
           false,
           UpdateTransactionStatusTracerUtils.GatewayOutcomeResult(
             ClosePaymentOutcome.KO.toString(),
-            Optional.of("$expectedHttpErrorCode - [$expectedErrorDescription]"))))
+            Optional.of("HTTP code:[$expectedHttpErrorCode] - descr:[$expectedErrorDescription]"))))
   }
 
   @Test


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/212
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add tracing for ClosePayment processed requests.
For each performed close payment a span will be add that will trace: pspId, paymentTypeCode, if the transaction is performed with an onboarded or not method, clientId and the Node outcome (OK, KO and eventual error with http and error description)
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to add monitoring to all performed close payments and allow to distinguish close payment operation by client, pspId, Node outcome and so on
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + test in DEV environment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.