### PR TITLE
fix: POST save usage for ongoing transactions

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/UserStatsServiceClient.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/UserStatsServiceClient.kt
@@ -26,6 +26,10 @@ class UserStatsServiceClient(
     userId: UUID,
     userLastPaymentMethodDataDto: UserLastPaymentMethodData
   ): Mono<Unit> {
+    logger.info(
+      "Saving last method used for user with id: [{}], last used method: [{}]",
+      userId,
+      userLastPaymentMethodDataDto)
     return userStatsServiceApi
       .saveLastPaymentMethodUsed(
         UserLastPaymentMethodRequest().userId(userId).details(userLastPaymentMethodDataDto))


### PR DESCRIPTION
perform POST save usage api call also for those transactions that have reach a state after AUTHORIZATION_REQUESTED status once received event

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Authorization requested event is received after a delay after the authorization is performed. 
This mean that the transaction could be in a next status rather then AUTHORIZATION_REQUESTED one once authorization requested event is written in queue.
For those cases only the POST save last usage api call have to be invoked
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is required in order to update last usage correctly for all transactions, also the ones that have reach a next status than AUTHORIZATION_REQUESTED one
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.