### PR TITLE
feat(close payment): add automatic refund for 400 and 404 response codes

### DIFF
--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionClosePaymentRetryQueueConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v1/TransactionClosePaymentRetryQueueConsumerTests.kt
@@ -11,7 +11,6 @@ import it.pagopa.ecommerce.commons.queues.TracingUtils
 import it.pagopa.ecommerce.commons.queues.TracingUtilsTests
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils.*
 import it.pagopa.ecommerce.eventdispatcher.client.PaymentGatewayClient
-import it.pagopa.ecommerce.eventdispatcher.exceptions.ClosePaymentErrorResponseException
 import it.pagopa.ecommerce.eventdispatcher.queues.v2.helpers.ClosePaymentOutcome
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsEventStoreRepository
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsViewRepository
@@ -20,7 +19,6 @@ import it.pagopa.ecommerce.eventdispatcher.services.eventretry.v1.RefundRetrySer
 import it.pagopa.ecommerce.eventdispatcher.services.v1.NodeService
 import it.pagopa.ecommerce.eventdispatcher.utils.DeadLetterTracedQueueAsyncClient
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto
-import it.pagopa.generated.ecommerce.nodo.v2.dto.ErrorDto
 import java.time.ZonedDateTime
 import java.util.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,7 +31,6 @@ import org.mockito.Captor
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
-import org.springframework.http.HttpStatus
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toFlux
 import reactor.test.StepVerifier
@@ -153,73 +150,4 @@ class TransactionClosePaymentRetryQueueConsumerTests {
       TransactionClosureData.Outcome.OK,
       closedEventStoreRepositoryCaptor.value.data.responseOutcome)
   }
-
-  @Test
-  fun `consumer processes refund on close payment 400 and Unacceptable outcome when token has expired error description`() =
-    runTest {
-      val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
-      val authRequestedEvent = transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
-      val authCompletedEvent = transactionAuthorizationCompletedEvent() as TransactionEvent<Any>
-      val closureRetriedEvent = transactionClosureRetriedEvent(1) as TransactionEvent<Any>
-      val closureErrorEvent = transactionClosureErrorEvent() as TransactionEvent<Any>
-      val eitherEvent: Either<TransactionClosureErrorEvent, TransactionClosureRetriedEvent> =
-        Either.right(closureRetriedEvent as TransactionClosureRetriedEvent)
-
-      val events =
-        listOf(activationEvent, authRequestedEvent, authCompletedEvent, closureErrorEvent)
-
-      val transactionDocument =
-        transactionDocument(
-          TransactionStatusDto.CANCELLATION_REQUESTED,
-          ZonedDateTime.parse(activationEvent.creationDate))
-
-      val expectedUpdatedTransactionCanceled =
-        transactionDocument(
-          TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.parse(activationEvent.creationDate))
-
-      val transactionId = TransactionId(TRANSACTION_ID)
-
-      /* preconditions */
-      given(checkpointer.success()).willReturn(Mono.empty())
-      given(
-          transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
-            TRANSACTION_ID))
-        .willReturn(events.toFlux())
-      given(
-          transactionsRefundedEventStoreRepository.save(refundEventStoreRepositoryCaptor.capture()))
-        .willAnswer { Mono.just(it.arguments[0]) }
-      given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
-        .willReturn(Mono.just(transactionDocument))
-      given(transactionsViewRepository.save(viewArgumentCaptor.capture())).willAnswer {
-        Mono.just(it.arguments[0])
-      }
-      given(transactionClosedEventRepository.save(closedEventStoreRepositoryCaptor.capture()))
-        .willAnswer { Mono.just(it.arguments[0]) }
-      given(nodeService.closePayment(transactionId, ClosePaymentOutcome.OK))
-        .willThrow(
-          ClosePaymentErrorResponseException(
-            HttpStatus.BAD_REQUEST,
-            ErrorDto("KO", ClosePaymentErrorResponseException.UNACCEPTABLE_OUTCOME_TOKEN_EXPIRED)))
-      given(deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any(), any()))
-        .willReturn(Mono.empty())
-      /* test */
-
-      StepVerifier.create(
-          transactionClosureEventsConsumer.messageReceiver(
-            eitherEvent to MOCK_TRACING_INFO, checkpointer))
-        .expectNext(Unit)
-        .verifyComplete()
-
-      /* Asserts */
-      verify(checkpointer, Mockito.times(1)).success()
-      verify(nodeService, Mockito.times(1)).closePayment(transactionId, ClosePaymentOutcome.OK)
-      verify(transactionClosedEventRepository, Mockito.times(0))
-        .save(
-          any()) // FIXME: Unable to use better argument captor because of misbehaviour in static
-      verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-      // mocking
-      verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransactionCanceled)
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any())
-      assertEquals(TransactionStatusDto.REFUND_REQUESTED, viewArgumentCaptor.value.status)
-    }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Extend automatic refund on Node ClosePayment to properly handle 4xx errors as per https://pagopa.atlassian.net/browse/CHK-3553 specifications

Here an overall on automatic action performed by eCommerce for errors performing Close payment
| http error code                | description                                   | automatic refund | retry |
|--------------------------------|-----------------------------------------------|------------------|-------|
| 400                            | any                                           | ✅                | ❌     |
| 404                            | any                                           | ✅                | ❌     |
| 422                            | `Node did not receive RPT yet`                | ✅                | ❌     |
| 422                            | Any other than `Node did not receive RPT yet` | ❌                | ❌     |
| any other 4xx                  | any                                           | ❌                | ❌     |
| 5xx                            | any                                           | ❌                | ✅     |
| other errors (such as timeout) | -                                             | ❌                | ✅     |

<!--- Describe your changes in detail -->

#### Motivation and Context
Those modification will automatize refund operation performed by eCommerce for all unrecoverable cases (4xx) where retry will have no meaning and refund operation could be done.

As for now Node will return only two descriptions for 422 http error code:
- `Node did not receive RPT yet`
- `Outcome already acquired`

Refund, for this case, can be done only for `Node did not receive RPT yet` and not for the `Outcome already acquired` description.
For 422 http response code an 1-1 description check have been made so that transaction is automatically refund only for `Node did not receive RPT yet` description: no automatic action is performed for any other description.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.