### PR TITLE
feat(Node close payment): save error into events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<kotlinx-coroutines.version>1.6.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.8</jacoco.version>
-		<pagopa-ecommerce-commons.version>1.31.2</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>1.32.0</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**,
 			**/it/pagopa/ecommerce/eventdispatcher/validation/**

--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,8 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+					<scmVersion>CHK-3614-close-payment-error</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -598,8 +598,6 @@
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
 					<scmVersionType>tag</scmVersionType>
 					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
-					<scmVersionType>branch</scmVersionType>
-					<scmVersion>CHK-3614-close-payment-error</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClient.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/client/NodeClient.kt
@@ -81,7 +81,7 @@ class NodeClient(
           "Received closePaymentV2 Response Status Error for transactionId [$transactionId]",
           exception)
         if (exception is ResponseStatusException) {
-          throw ClosePaymentErrorResponseException(
+          ClosePaymentErrorResponseException(
             exception.status,
             runCatching { objectMapper.readValue(exception.reason, ErrorDto::class.java) }
               .onFailure {
@@ -89,7 +89,7 @@ class NodeClient(
               }
               .getOrNull())
         } else {
-          throw ClosePaymentErrorResponseException(null, null)
+          ClosePaymentErrorResponseException(null, null)
         }
       }
   }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -82,7 +82,11 @@ data class ClosePaymentEvent(
         ClosureErrorData(
           exception.statusCode,
           exception.errorResponse?.description,
-          ClosureErrorData.ErrorType.KO_RESPONSE_RECEIVED)
+          if (exception.statusCode != null) {
+            ClosureErrorData.ErrorType.KO_RESPONSE_RECEIVED
+          } else {
+            ClosureErrorData.ErrorType.COMMUNICATION_ERROR
+          })
       } else {
         ClosureErrorData(null, null, ClosureErrorData.ErrorType.COMMUNICATION_ERROR)
       }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/AuthorizationStateRetrieverRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/AuthorizationStateRetrieverRetryService.kt
@@ -46,7 +46,8 @@ class AuthorizationStateRetrieverRetryService(
   override fun buildRetryEvent(
     transactionId: TransactionId,
     transactionRetriedData: TransactionRetriedData,
-    transactionGatewayAuthorizationData: TransactionGatewayAuthorizationData?
+    transactionGatewayAuthorizationData: TransactionGatewayAuthorizationData?,
+    throwable: Throwable?
   ): TransactionEvent<BaseTransactionRetriedData> =
     TransactionAuthorizationOutcomeWaitingEvent(transactionId.value(), transactionRetriedData)
       as TransactionEvent<BaseTransactionRetriedData>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/ClosureRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/ClosureRetryService.kt
@@ -16,7 +16,6 @@ import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import reactor.core.publisher.Mono
 
 @Service(ClosureRetryService.QUALIFIER)
 class ClosureRetryService(
@@ -88,19 +87,4 @@ class ClosureRetryService(
         .transactionActivatedData
         .paymentTokenValiditySeconds
         .toLong())
-
-  override fun storeEventAndUpdateView(
-    event: TransactionEvent<BaseTransactionRetriedData>,
-    newStatus: TransactionStatusDto
-  ): Mono<TransactionEvent<BaseTransactionRetriedData>> {
-    return Mono.just(event)
-      .flatMap { eventStoreRepository.save(it) }
-      .flatMap { viewRepository.findByTransactionId(it.transactionId) }
-      .cast(Transaction::class.java)
-      .flatMap {
-        it.status = newStatus
-        it.closureErrorData = (event as TransactionClosureRetriedEvent).data.closureErrorData
-        viewRepository.save(it).flatMap { Mono.just(event) }
-      }
-  }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/ClosureRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/ClosureRetryService.kt
@@ -99,7 +99,7 @@ class ClosureRetryService(
       .cast(Transaction::class.java)
       .flatMap {
         it.status = newStatus
-        it.closureErrorData = (event as TransactionClosureErrorEvent).data
+        it.closureErrorData = (event as TransactionClosureRetriedEvent).data.closureErrorData
         viewRepository.save(it).flatMap { Mono.just(event) }
       }
   }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/NotificationRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/NotificationRetryService.kt
@@ -45,7 +45,8 @@ class NotificationRetryService(
   override fun buildRetryEvent(
     transactionId: TransactionId,
     transactionRetriedData: TransactionRetriedData,
-    transactionGatewayAuthorizationData: TransactionGatewayAuthorizationData?
+    transactionGatewayAuthorizationData: TransactionGatewayAuthorizationData?,
+    throwable: Throwable?
   ): TransactionEvent<BaseTransactionRetriedData> =
     TransactionUserReceiptAddRetriedEvent(transactionId.value(), transactionRetriedData)
       as TransactionEvent<BaseTransactionRetriedData>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RefundRetryService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RefundRetryService.kt
@@ -1,11 +1,7 @@
 package it.pagopa.ecommerce.eventdispatcher.services.eventretry.v2
 
 import com.azure.storage.queue.QueueAsyncClient
-import it.pagopa.ecommerce.commons.documents.v2.BaseTransactionRetriedData
-import it.pagopa.ecommerce.commons.documents.v2.TransactionEvent
-import it.pagopa.ecommerce.commons.documents.v2.TransactionRefundRetriedData
-import it.pagopa.ecommerce.commons.documents.v2.TransactionRefundRetriedEvent
-import it.pagopa.ecommerce.commons.documents.v2.TransactionRetriedData
+import it.pagopa.ecommerce.commons.documents.v2.*
 import it.pagopa.ecommerce.commons.documents.v2.authorization.TransactionGatewayAuthorizationData
 import it.pagopa.ecommerce.commons.domain.TransactionId
 import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransaction
@@ -46,7 +42,8 @@ class RefundRetryService(
   override fun buildRetryEvent(
     transactionId: TransactionId,
     transactionRetriedData: TransactionRetriedData,
-    transactionGatewayAuthorizationData: TransactionGatewayAuthorizationData?
+    transactionGatewayAuthorizationData: TransactionGatewayAuthorizationData?,
+    throwable: Throwable?
   ): TransactionEvent<BaseTransactionRetriedData> =
     TransactionRefundRetriedEvent(
       transactionId.value(),

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RetryEventService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RetryEventService.kt
@@ -48,7 +48,7 @@ abstract class RetryEventService<E>(
         baseTransaction.transactionId,
         TransactionRetriedData(retriedCount + 1),
         transactionGatewayAuthorizationData,
-        null)
+        throwable)
     val visibilityTimeout = Duration.ofSeconds((retryOffset * retryEvent.data.retryCount).toLong())
     return Mono.just(retryEvent)
       .filter { it.data.retryCount <= maxAttempts }

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RetryEventService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RetryEventService.kt
@@ -86,7 +86,7 @@ abstract class RetryEventService<E>(
     visibilityTimeout: Duration
   ): Boolean
 
-  open fun storeEventAndUpdateView(event: E, newStatus: TransactionStatusDto): Mono<E> =
+  private fun storeEventAndUpdateView(event: E, newStatus: TransactionStatusDto): Mono<E> =
     Mono.just(event)
       .flatMap { retryEventStoreRepository.save(it) }
       .flatMap { viewRepository.findByTransactionId(it.transactionId) }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsQueueConsumerTest.kt
@@ -163,7 +163,8 @@ class TransactionNotificationsQueueConsumerTest {
     verify(transactionsEventStoreRepository, times(1))
       .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
     verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-    verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(notificationRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(transactionsViewRepository, times(1)).save(any())
     verify(refundRequestedAsyncClient, times(0))
       .sendMessageWithResponse(any<QueueEvent<*>>(), any(), any())
@@ -240,7 +241,8 @@ class TransactionNotificationsQueueConsumerTest {
       verify(transactionRefundRepository, times(1)).save(any())
       verify(refundRequestedAsyncClient, times(1))
         .sendMessageWithResponse(any<QueueEvent<*>>(), any(), any())
-      verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(2)).save(any())
       verify(transactionUserReceiptRepository, times(1)).save(any())
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
@@ -312,7 +314,8 @@ class TransactionNotificationsQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -389,7 +392,8 @@ class TransactionNotificationsQueueConsumerTest {
       verify(transactionRefundRepository, times(1)).save(any())
       verify(refundRequestedAsyncClient, times(1))
         .sendMessageWithResponse(any<QueueEvent<*>>(), any(), any())
-      verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(2)).save(any())
       verify(transactionUserReceiptRepository, times(1)).save(any())
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
@@ -454,7 +458,7 @@ class TransactionNotificationsQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
@@ -465,7 +469,8 @@ class TransactionNotificationsQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -523,7 +528,7 @@ class TransactionNotificationsQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
@@ -534,7 +539,8 @@ class TransactionNotificationsQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -597,7 +603,7 @@ class TransactionNotificationsQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.error(RuntimeException("Error enqueueing notification retry event")))
       given(
           deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
@@ -613,7 +619,8 @@ class TransactionNotificationsQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(transactionUserReceiptRepository, times(1)).save(any())
@@ -675,7 +682,8 @@ class TransactionNotificationsQueueConsumerTest {
     verify(transactionsEventStoreRepository, times(1))
       .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
     verify(notificationsServiceClient, times(0)).sendNotificationEmail(any())
-    verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(notificationRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(transactionsViewRepository, times(0)).save(any())
     verify(transactionRefundRepository, times(0)).save(any())
     verify(refundRequestedAsyncClient, times(0))
@@ -828,7 +836,7 @@ class TransactionNotificationsQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
@@ -839,7 +847,8 @@ class TransactionNotificationsQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumerTest.kt
@@ -162,7 +162,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
     verify(transactionUserReceiptRepository, times(1)).save(any())
     verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-    verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(notificationRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(refundRequestedAsyncClient, times(0))
       .sendMessageWithResponse(any<QueueEvent<*>>(), any(), any())
     verify(transactionsViewRepository, times(1)).save(any())
@@ -235,7 +236,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
     verify(transactionsEventStoreRepository, times(1))
       .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
     verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-    verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(notificationRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(transactionsViewRepository, times(2)).save(any())
     verify(transactionRefundRepository, times(1)).save(any())
     verify(refundRequestedAsyncClient, times(1))
@@ -312,7 +314,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
       verify(transactionUserReceiptRepository, times(1)).save(any())
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -386,7 +389,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(2)).save(any())
       verify(transactionRefundRepository, times(1)).save(any())
       verify(refundRequestedAsyncClient, times(1))
@@ -456,7 +460,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
@@ -467,7 +471,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(0)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -519,7 +524,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
@@ -530,7 +535,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(0)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -584,7 +590,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
@@ -595,7 +601,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(0)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -649,7 +656,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), isNull(), anyOrNull()))
+            any(), capture(retryCountCaptor), isNull(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       StepVerifier.create(
           transactionNotificationsRetryQueueConsumer.messageReceiver(
@@ -661,7 +668,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
       verify(notificationRetryService, times(1))
-        .enqueueRetryEvent(any(), any(), isNull(), anyOrNull())
+        .enqueueRetryEvent(any(), any(), isNull(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(0)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
@@ -715,7 +722,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
 
       given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
@@ -735,13 +742,15 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(0)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(refundRequestedAsyncClient, times(0))
         .sendMessageWithResponse(any<QueueEvent<*>>(), any(), any())
       verify(transactionUserReceiptRepository, times(0)).save(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(userReceiptMailBuilder, times(1)).buildNotificationEmailRequestDto(baseTransaction)
       assertEquals(attempt, retryCountCaptor.value)
     }
@@ -791,7 +800,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
 
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(
           Mono.error(
             NoRetryAttemptsLeftException(
@@ -819,7 +828,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(0)).save(any())
       verify(transactionRefundRepository, times(0)).save(any())
       verify(transactionUserReceiptRepository, times(0)).save(any())
@@ -889,7 +899,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(
           Mono.error(
             NoRetryAttemptsLeftException(
@@ -921,7 +931,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(1)).save(any())
       verify(refundRequestedAsyncClient, times(1))
@@ -986,7 +997,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
     verify(transactionsEventStoreRepository, times(1))
       .findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)
     verify(notificationsServiceClient, times(0)).sendNotificationEmail(any())
-    verify(notificationRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(notificationRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(transactionsViewRepository, times(0)).save(any())
     verify(transactionRefundRepository, times(0)).save(any())
     verify(refundRequestedAsyncClient, times(0))
@@ -1055,7 +1067,7 @@ class TransactionNotificationsRetryQueueConsumerTest {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(
           notificationRetryService.enqueueRetryEvent(
-            any(), capture(retryCountCaptor), any(), anyOrNull()))
+            any(), capture(retryCountCaptor), any(), anyOrNull(), anyOrNull()))
         .willReturn(
           Mono.error(
             NoRetryAttemptsLeftException(
@@ -1087,7 +1099,8 @@ class TransactionNotificationsRetryQueueConsumerTest {
       verify(transactionsEventStoreRepository, times(1))
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
       verify(notificationsServiceClient, times(1)).sendNotificationEmail(any())
-      verify(notificationRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(notificationRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(transactionsViewRepository, times(1)).save(any())
       verify(transactionRefundRepository, times(1)).save(any())
       verify(refundRequestedAsyncClient, times(1))

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionRefundRetryQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionRefundRetryQueueConsumerTest.kt
@@ -146,7 +146,8 @@ class TransactionRefundRetryQueueConsumerTest {
     given(refundService.requestNpgRefund(any(), any(), any(), any(), any(), any()))
       .willReturn(Mono.just(gatewayClientResponse))
     given(
-        refundRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture(), any(), anyOrNull()))
+        refundRetryService.enqueueRetryEvent(
+          any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
       .willReturn(
@@ -173,7 +174,8 @@ class TransactionRefundRetryQueueConsumerTest {
       TransactionEventCode.TRANSACTION_REFUNDED_EVENT,
       TransactionEventCode.valueOf(transactionRefundEventStoreCaptor.value.eventCode),
       "Unexpected event code")
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(refundRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @Test
@@ -227,7 +229,7 @@ class TransactionRefundRetryQueueConsumerTest {
         .willReturn(Mono.error(BadGatewayException("mockError")))
       given(
           refundRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
         .willReturn(
@@ -248,7 +250,8 @@ class TransactionRefundRetryQueueConsumerTest {
       verify(refundService, times(1)).requestNpgRefund(any(), any(), any(), any(), any(), any())
       verify(transactionsRefundedEventStoreRepository, times(1)).save(any())
       verify(transactionsViewRepository, times(1)).save(any())
-      verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(refundRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(retryCount, retryCountCaptor.value)
       assertEquals(TransactionStatusDto.REFUND_ERROR, transactionViewRepositoryCaptor.value.status)
       assertEquals(
@@ -309,7 +312,8 @@ class TransactionRefundRetryQueueConsumerTest {
       .willReturn(
         Mono.just(RefundResponseDto().operationId("operationId").operationTime("operationTime")))
     given(
-        refundRetryService.enqueueRetryEvent(any(), retryCountCaptor.capture(), any(), anyOrNull()))
+        refundRetryService.enqueueRetryEvent(
+          any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
       .willReturn(
@@ -337,7 +341,8 @@ class TransactionRefundRetryQueueConsumerTest {
       TransactionEventCode.TRANSACTION_REFUNDED_EVENT,
       TransactionEventCode.valueOf(transactionRefundEventStoreCaptor.value.eventCode),
       "Unexpected event code")
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(refundRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @Test
@@ -394,7 +399,7 @@ class TransactionRefundRetryQueueConsumerTest {
         .willReturn(Mono.error(BadGatewayException("mockError")))
       given(
           refundRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), isNull(), anyOrNull()))
+            any(), retryCountCaptor.capture(), isNull(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(transactionsViewRepository.findByTransactionId(TransactionTestUtils.TRANSACTION_ID))
         .willReturn(
@@ -415,7 +420,8 @@ class TransactionRefundRetryQueueConsumerTest {
       verify(refundService, times(1)).requestNpgRefund(any(), any(), any(), any(), any(), any())
       verify(transactionsRefundedEventStoreRepository, times(1)).save(any())
       verify(transactionsViewRepository, times(1)).save(any())
-      verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any(), isNull(), anyOrNull())
+      verify(refundRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), isNull(), anyOrNull(), anyOrNull())
       assertEquals(retryCount, retryCountCaptor.value)
       assertEquals(TransactionStatusDto.REFUND_ERROR, transactionViewRepositoryCaptor.value.status)
       assertEquals(
@@ -474,7 +480,7 @@ class TransactionRefundRetryQueueConsumerTest {
         .willReturn(Mono.error(BadGatewayException("mockError")))
       given(
           refundRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(authorizationStateRetrieverService.performGetOrder(any()))
         .willReturn(npgAuthorizedOrderResponse("operationId", "paymentEnd2EndId"))
@@ -490,7 +496,8 @@ class TransactionRefundRetryQueueConsumerTest {
       verify(refundService, times(1)).requestNpgRefund(any(), any(), any(), any(), any(), any())
       verify(transactionsRefundedEventStoreRepository, times(0)).save(any())
       verify(transactionsViewRepository, times(0)).save(any())
-      verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(refundRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(retryCount, retryCountCaptor.value)
     }
 
@@ -530,7 +537,7 @@ class TransactionRefundRetryQueueConsumerTest {
         .willReturn(Mono.just(gatewayClientResponse))
       given(
           refundRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(
           deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
@@ -549,7 +556,8 @@ class TransactionRefundRetryQueueConsumerTest {
       verify(refundService, times(0)).requestNpgRefund(any(), any(), any(), any(), any(), any())
       verify(transactionsRefundedEventStoreRepository, times(0)).save(any())
       verify(transactionsViewRepository, times(0)).save(any())
-      verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(refundRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
           argThat<BinaryData> {
@@ -628,7 +636,7 @@ class TransactionRefundRetryQueueConsumerTest {
         .willReturn(Mono.error(BadGatewayException("mockError")))
       given(
           refundRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.error(NoRetryAttemptsLeftException("No retry attempt left")))
       given(
           deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
@@ -648,7 +656,8 @@ class TransactionRefundRetryQueueConsumerTest {
       verify(refundService, times(1)).requestNpgRefund(any(), any(), any(), any(), any(), any())
       verify(transactionsRefundedEventStoreRepository, times(0)).save(any())
       verify(transactionsViewRepository, times(0)).save(any())
-      verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(refundRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(retryCount, retryCountCaptor.value)
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
@@ -174,7 +174,8 @@ class TransactionsRefundEventsConsumerTests {
       verify(refundService, Mockito.times(0))
         .requestNpgRefund(any(), any(), any(), any(), any(), any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
-      verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(refundRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     }
 
   @Test
@@ -258,7 +259,8 @@ class TransactionsRefundEventsConsumerTests {
           paymentMethod =
             NpgClient.PaymentMethod.valueOf(authorizationRequestEvent.data.paymentMethodName))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-      verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(refundRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       val storedEvent = refundEventStoreCaptor.value
       assertEquals(
         TransactionEventCode.TRANSACTION_REFUND_ERROR_EVENT.toString(), storedEvent.eventCode)
@@ -353,7 +355,8 @@ class TransactionsRefundEventsConsumerTests {
         paymentMethod =
           NpgClient.PaymentMethod.valueOf(authorizationRequestEvent.data.paymentMethodName))
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(refundRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     val storedEvent = refundEventStoreCaptor.value
     assertEquals(TransactionEventCode.TRANSACTION_REFUNDED_EVENT.toString(), storedEvent.eventCode)
     assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
@@ -408,7 +411,7 @@ class TransactionsRefundEventsConsumerTests {
         .willAnswer { Mono.just(it.arguments[0]) }
       given(refundService.requestNpgRefund(any(), any(), any(), any(), any(), any()))
         .willThrow(RefundNotAllowedException(transaction.transactionId))
-      given(refundRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+      given(refundRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
         .willReturn(
@@ -453,7 +456,8 @@ class TransactionsRefundEventsConsumerTests {
           paymentMethod =
             NpgClient.PaymentMethod.valueOf(authorizationRequestEvent.data.paymentMethodName))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-      verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(refundRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
           any<BinaryData>(),
@@ -656,7 +660,8 @@ class TransactionsRefundEventsConsumerTests {
     verify(refundService, times(0)).requestNpgRefund(any(), any(), any(), any(), any(), any())
     verify(refundService, times(0)).requestRedirectRefund(any(), any(), any(), any(), any())
     verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(refundRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @ParameterizedTest
@@ -740,7 +745,8 @@ class TransactionsRefundEventsConsumerTests {
         paymentTypeCode = expectedPaymentTypeCode,
         pspId = expectedPspId)
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-    verify(refundRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(refundRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     val storedEvent = refundEventStoreCaptor.value
     assertEquals(TransactionEventCode.TRANSACTION_REFUNDED_EVENT.toString(), storedEvent.eventCode)
     assertEquals(TransactionStatusDto.REFUND_REQUESTED, storedEvent.data.statusBeforeRefunded)
@@ -789,7 +795,7 @@ class TransactionsRefundEventsConsumerTests {
     given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
       .willReturn(
         mono { transactionDocument(TransactionStatusDto.REFUND_REQUESTED, ZonedDateTime.now()) })
-    given(refundRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+    given(refundRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     Hooks.onOperatorDebug()
     /* test */
@@ -812,7 +818,8 @@ class TransactionsRefundEventsConsumerTests {
         paymentTypeCode = any(),
         pspId = any())
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
-    verify(refundRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(refundRetryService, times(1))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
 
     val storedEvent = refundEventStoreCaptor.value
     assertEquals(

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuthorizationRequestedHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuthorizationRequestedHelperTests.kt
@@ -212,7 +212,7 @@ class AuthorizationRequestedHelperTests {
 
     given(
         authorizationStateRetrieverRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), any()))
+          any(), retryCountCaptor.capture(), any(), any(), anyOrNull()))
       .willReturn(Mono.empty())
     given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
       .willReturn(
@@ -239,7 +239,7 @@ class AuthorizationRequestedHelperTests {
     /* Asserts */
     verify(checkpointer, times(1)).success()
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(authorizationStateRetrieverService, times(1))
       .getStateNpg(
         transactionId,
@@ -313,7 +313,7 @@ class AuthorizationRequestedHelperTests {
 
     given(
         authorizationStateRetrieverRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), any()))
+          any(), retryCountCaptor.capture(), any(), any(), anyOrNull()))
       .willReturn(Mono.empty())
     given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
       .willReturn(
@@ -339,7 +339,7 @@ class AuthorizationRequestedHelperTests {
     /* Asserts */
     verify(checkpointer, times(1)).success()
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(authorizationStateRetrieverService, times(1))
       .getStateNpg(
         transactionId,
@@ -413,7 +413,7 @@ class AuthorizationRequestedHelperTests {
 
     given(
         authorizationStateRetrieverRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), any()))
+          any(), retryCountCaptor.capture(), any(), any(), anyOrNull()))
       .willReturn(Mono.empty())
     given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
       .willReturn(
@@ -439,7 +439,7 @@ class AuthorizationRequestedHelperTests {
     /* Asserts */
     verify(checkpointer, times(1)).success()
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(authorizationStateRetrieverService, times(1))
       .getStateNpg(
         transactionId,
@@ -499,7 +499,7 @@ class AuthorizationRequestedHelperTests {
 
       given(
           authorizationStateRetrieverRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
         .willReturn(
@@ -525,7 +525,7 @@ class AuthorizationRequestedHelperTests {
       /* Asserts */
       verify(checkpointer, times(1)).success()
       verify(authorizationStateRetrieverRetryService, times(1))
-        .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(authorizationStateRetrieverService, times(1))
         .getStateNpg(
           transactionId,
@@ -586,7 +586,7 @@ class AuthorizationRequestedHelperTests {
 
       given(
           authorizationStateRetrieverRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
         .willReturn(
@@ -612,7 +612,7 @@ class AuthorizationRequestedHelperTests {
       /* Asserts */
       verify(checkpointer, times(1)).success()
       verify(authorizationStateRetrieverRetryService, times(1))
-        .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(authorizationStateRetrieverService, times(1))
         .getStateNpg(
           transactionId,
@@ -659,7 +659,7 @@ class AuthorizationRequestedHelperTests {
 
       given(
           authorizationStateRetrieverRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), any()))
+            any(), retryCountCaptor.capture(), any(), any(), anyOrNull()))
         .willReturn(Mono.empty())
       given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
         .willReturn(
@@ -684,7 +684,7 @@ class AuthorizationRequestedHelperTests {
       /* Asserts */
       verify(checkpointer, times(1)).success()
       verify(authorizationStateRetrieverRetryService, times(0))
-        .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(authorizationStateRetrieverService, times(0))
         .getStateNpg(any(), any(), any(), any(), any())
       verify(userStatsServiceClient, times(0)).saveLastUsage(any(), any())
@@ -714,7 +714,8 @@ class AuthorizationRequestedHelperTests {
           transactionId.value()))
       .willReturn(Flux.fromIterable(events))
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(authorizationStateRetrieverService.getStateNpg(any(), any(), any(), any(), any()))
       .willReturn(Mono.error(NpgServerErrorException("Error retrieving transaction status")))
@@ -742,7 +743,7 @@ class AuthorizationRequestedHelperTests {
     verify(transactionsServiceClient, times(0)).patchAuthRequest(any(), any())
     verify(userStatsServiceClient, times(0)).saveLastUsage(any(), any())
     verify(authorizationStateRetrieverRetryService, times(1))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
   }
@@ -771,7 +772,8 @@ class AuthorizationRequestedHelperTests {
           transactionId.value()))
       .willReturn(Flux.fromIterable(events))
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(authorizationStateRetrieverService.getStateNpg(any(), any(), any(), any(), any()))
       .willReturn(
@@ -797,7 +799,7 @@ class AuthorizationRequestedHelperTests {
     verify(transactionsServiceClient, times(0)).patchAuthRequest(any(), any())
     verify(userStatsServiceClient, times(0)).saveLastUsage(any(), any())
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
   }
@@ -865,7 +867,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     // Test
     StepVerifier.create(
@@ -889,7 +892,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @ParameterizedTest
@@ -954,7 +957,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     // Test
     StepVerifier.create(
@@ -978,7 +982,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(1))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @Test
@@ -1039,7 +1043,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     // Test
     StepVerifier.create(
@@ -1063,7 +1068,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @Test
@@ -1112,7 +1117,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
 
     // Test
@@ -1136,7 +1142,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(1))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @ParameterizedTest
@@ -1535,7 +1541,8 @@ class AuthorizationRequestedHelperTests {
           transactionId.value()))
       .willReturn(Flux.fromIterable(events))
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(authorizationStateRetrieverService.getStateNpg(any(), any(), any(), any(), any()))
       .willReturn(
@@ -1566,7 +1573,7 @@ class AuthorizationRequestedHelperTests {
     verify(userStatsServiceClient, times(0)).saveLastUsage(any(), any())
     verify(transactionsServiceClient, times(0)).patchAuthRequest(any(), any())
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
   }
@@ -1594,7 +1601,8 @@ class AuthorizationRequestedHelperTests {
           transactionId.value()))
       .willReturn(Flux.fromIterable(events))
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(authRequestedQueueAsyncClient.sendMessageWithResponse(any<BinaryData>(), any(), any()))
       .willReturn(queueSuccessfulResponse())
@@ -1623,7 +1631,7 @@ class AuthorizationRequestedHelperTests {
     verify(transactionsServiceClient, times(0)).patchAuthRequest(any(), any())
     verify(userStatsServiceClient, times(0)).saveLastUsage(any(), any())
     verify(authorizationStateRetrieverRetryService, times(1))
-      .enqueueRetryEvent(any(), eq(0), any(), anyOrNull())
+      .enqueueRetryEvent(any(), eq(0), any(), anyOrNull(), anyOrNull())
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     /*verify(authRequestedOutcomeWaitingQueueAsyncClient, times(1))
@@ -1709,7 +1717,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(userStatsServiceClient.saveLastUsage(any(), any())).willReturn(Mono.empty())
     // Test
@@ -1734,7 +1743,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @ParameterizedTest
@@ -1802,7 +1811,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(userStatsServiceClient.saveLastUsage(any(), any())).willReturn(Mono.empty())
     // Test
@@ -1827,7 +1837,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(1))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @Test
@@ -1891,7 +1901,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(authRequestedQueueAsyncClient.sendMessageWithResponse(any<BinaryData>(), any(), any()))
       .willReturn(queueSuccessfulResponse())
@@ -1916,7 +1927,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(authRequestedQueueAsyncClient, times(0))
       .sendMessageWithResponse(any<BinaryData>(), any(), any())
   }
@@ -1969,7 +1980,8 @@ class AuthorizationRequestedHelperTests {
         deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(any<BinaryData>(), any()))
       .willReturn(mono {})
     given(
-        authorizationStateRetrieverRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+        authorizationStateRetrieverRetryService.enqueueRetryEvent(
+          any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     given(userStatsServiceClient.saveLastUsage(any(), any())).willReturn(Mono.empty())
 
@@ -1994,7 +2006,7 @@ class AuthorizationRequestedHelperTests {
     verify(deadLetterTracedQueueAsyncClient, times(0))
       .sendAndTraceDeadLetterQueueEvent(any(), any())
     verify(authorizationStateRetrieverRetryService, times(1))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
   }
 
   @ParameterizedTest
@@ -2062,7 +2074,7 @@ class AuthorizationRequestedHelperTests {
 
     given(
         authorizationStateRetrieverRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), any()))
+          any(), retryCountCaptor.capture(), any(), any(), anyOrNull()))
       .willReturn(Mono.empty())
     given(transactionsViewRepository.findByTransactionId(TRANSACTION_ID))
       .willReturn(
@@ -2088,7 +2100,7 @@ class AuthorizationRequestedHelperTests {
     /* Asserts */
     verify(checkpointer, times(1)).success()
     verify(authorizationStateRetrieverRetryService, times(0))
-      .enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(authorizationStateRetrieverService, times(1))
       .getStateNpg(
         transactionId,

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
@@ -73,7 +73,8 @@ class ClosePaymentHelperTests {
 
   private val transactionsEventStoreRepository: TransactionsEventStoreRepository<Any> = mock()
 
-  private val transactionClosureErrorEventStoreRepository: TransactionsEventStoreRepository<Void> =
+  private val transactionClosureErrorEventStoreRepository:
+    TransactionsEventStoreRepository<ClosureErrorData> =
     mock()
 
   private val transactionsViewRepository: TransactionsViewRepository = mock()
@@ -111,7 +112,7 @@ class ClosePaymentHelperTests {
 
   @Captor
   private lateinit var closureErrorEventStoreRepositoryCaptor:
-    ArgumentCaptor<TransactionEvent<Void>>
+    ArgumentCaptor<TransactionEvent<ClosureErrorData>>
 
   @Captor private lateinit var retryCountCaptor: ArgumentCaptor<Int>
   private val strictJsonSerializerProviderV2 = QueuesConsumerConfig().strictSerializerProviderV2()

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
@@ -203,7 +203,8 @@ class ClosePaymentHelperTests {
       verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
 
       verify(transactionsViewRepository, Mockito.times(0)).save(expectedUpdatedTransaction)
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
           argThat<BinaryData> {
@@ -278,7 +279,8 @@ class ClosePaymentHelperTests {
     verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
 
     verify(transactionsViewRepository, Mockito.times(0)).save(expectedUpdatedTransaction)
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(deadLetterTracedQueueAsyncClient, times(1))
       .sendAndTraceDeadLetterQueueEvent(
         argThat<BinaryData> {
@@ -366,7 +368,8 @@ class ClosePaymentHelperTests {
           any()) // FIXME: Unable to use better argument captor because of misbehaviour in static
       // mocking
       verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       assertEquals(TransactionStatusDto.CLOSED, viewArgumentCaptor.value.status)
       assertEquals(
@@ -457,7 +460,8 @@ class ClosePaymentHelperTests {
       // mocking
       verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(TransactionStatusDto.UNAUTHORIZED, viewArgumentCaptor.value.status)
       assertEquals(
         TransactionEventCode.TRANSACTION_CLOSURE_FAILED_EVENT,
@@ -545,7 +549,8 @@ class ClosePaymentHelperTests {
       // mocking
       verify(transactionsViewRepository, Mockito.times(0)).save(expectedUpdatedTransaction)
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
           argThat<BinaryData> {
@@ -609,7 +614,8 @@ class ClosePaymentHelperTests {
       verify(nodeService, Mockito.times(0))
         .closePayment(TransactionId(TRANSACTION_ID), ClosePaymentOutcome.KO)
       verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
@@ -698,7 +704,8 @@ class ClosePaymentHelperTests {
       .save(any()) // FIXME: Unable to use better argument captor because of misbehaviour in static
     // mocking
     verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(updateTransactionStatusTracerUtils, times(1))
       .traceStatusUpdateOperation(
         ClosePaymentNodoStatusUpdate(
@@ -757,7 +764,8 @@ class ClosePaymentHelperTests {
     verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
     verify(transactionsViewRepository, Mockito.times(0)).save(any())
     verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(deadLetterTracedQueueAsyncClient, times(1))
       .sendAndTraceDeadLetterQueueEvent(
         argThat<BinaryData> {
@@ -858,7 +866,8 @@ class ClosePaymentHelperTests {
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(transactionsViewRepository, Mockito.times(2)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
 
       val expectedViewUpdateStatuses =
         listOf(TransactionStatusDto.CLOSED, TransactionStatusDto.REFUND_REQUESTED)
@@ -976,7 +985,8 @@ class ClosePaymentHelperTests {
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
       verify(transactionsViewRepository, Mockito.times(0)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(updateTransactionStatusTracerUtils, times(0)).traceStatusUpdateOperation(any())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
@@ -1044,7 +1054,7 @@ class ClosePaymentHelperTests {
           ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.KO })
       given(
           closureRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
 
       /* test */
@@ -1067,7 +1077,8 @@ class ClosePaymentHelperTests {
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
       verify(transactionsViewRepository, Mockito.times(1)).save(any())
 
-      verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
 
       val expectedViewUpdateStatuses =
         listOf(
@@ -1148,7 +1159,7 @@ class ClosePaymentHelperTests {
         ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.KO })
     given(
         closureRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), anyOrNull()))
+          any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
 
     /* test */
@@ -1170,7 +1181,8 @@ class ClosePaymentHelperTests {
     verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
     verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
     verify(transactionsViewRepository, Mockito.times(1)).save(any())
-    verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(1))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
 
     val expectedViewUpdateStatuses =
       listOf(
@@ -1263,7 +1275,7 @@ class ClosePaymentHelperTests {
 
     given(
         closureRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), anyOrNull()))
+          any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
       .willReturn(
         Mono.error(
           NoRetryAttemptsLeftException(
@@ -1289,7 +1301,8 @@ class ClosePaymentHelperTests {
     verify(transactionClosureErrorEventStoreRepository, Mockito.times(0)).save(any())
     verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
     verify(transactionsViewRepository, Mockito.times(0)).save(any())
-    verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(1))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(updateTransactionStatusTracerUtils, times(1))
       .traceStatusUpdateOperation(
         ClosePaymentNodoStatusUpdate(
@@ -1352,7 +1365,7 @@ class ClosePaymentHelperTests {
 
       given(
           closureRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.error(RuntimeException("Error enqueuing retry event")))
 
       given(
@@ -1380,7 +1393,8 @@ class ClosePaymentHelperTests {
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
       verify(transactionsViewRepository, Mockito.times(0))
         .save(argThat { it -> (it as Transaction).status == TransactionStatusDto.CLOSURE_ERROR })
-      verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(1))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
           argThat<BinaryData> {
@@ -1465,7 +1479,8 @@ class ClosePaymentHelperTests {
       .save(any()) // FIXME: Unable to use better argument captor because of misbehaviour in static
     // mocking
     verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransactionCanceled)
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).times(1)).deleteById(any())
     assertEquals(TransactionStatusDto.CANCELED, viewArgumentCaptor.value.status)
     assertEquals(
@@ -1535,7 +1550,8 @@ class ClosePaymentHelperTests {
       .save(any()) // FIXME: Unable to use better argument captor because of misbehaviour in static
     // mocking
     verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransactionCanceled)
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).times(1)).deleteById(any())
     assertEquals(TransactionStatusDto.CANCELED, viewArgumentCaptor.value.status)
     assertEquals(
@@ -1590,7 +1606,7 @@ class ClosePaymentHelperTests {
       Mono.just(it.arguments[0])
     }
 
-    given(closureRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+    given(closureRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     /* test */
 
@@ -1611,7 +1627,8 @@ class ClosePaymentHelperTests {
     verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).times(1)).deleteById(any())
     // mocking
     verify(transactionsViewRepository, Mockito.times(0)).save(expectedUpdatedTransactionCanceled)
-    verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(1))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
     assertEquals(
       TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT,
@@ -1664,7 +1681,7 @@ class ClosePaymentHelperTests {
         Mono.just(it.arguments[0])
       }
 
-      given(closureRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+      given(closureRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       /* test */
 
@@ -1688,7 +1705,7 @@ class ClosePaymentHelperTests {
       verify(transactionsViewRepository, Mockito.times(1)).save(any())
       verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
       verify(closureRetryService, times(0))
-        .enqueueRetryEvent(any(), any(), eq(MOCK_TRACING_INFO), anyOrNull())
+        .enqueueRetryEvent(any(), any(), eq(MOCK_TRACING_INFO), anyOrNull(), anyOrNull())
       assertEquals(
         TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT,
         TransactionEventCode.valueOf(closureErrorEventStoreRepositoryCaptor.value.eventCode))
@@ -1737,7 +1754,7 @@ class ClosePaymentHelperTests {
         Mono.just(it.arguments[0])
       }
 
-      given(closureRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull()))
+      given(closureRetryService.enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       /* test */
 
@@ -1761,7 +1778,7 @@ class ClosePaymentHelperTests {
       verify(transactionsViewRepository, Mockito.times(1)).save(any())
       verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
       verify(closureRetryService, times(0))
-        .enqueueRetryEvent(any(), any(), eq(MOCK_TRACING_INFO), anyOrNull())
+        .enqueueRetryEvent(any(), any(), eq(MOCK_TRACING_INFO), anyOrNull(), anyOrNull())
       assertEquals(
         TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT,
         TransactionEventCode.valueOf(closureErrorEventStoreRepositoryCaptor.value.eventCode))
@@ -1845,7 +1862,8 @@ class ClosePaymentHelperTests {
       verify(transactionClosedEventRepository, Mockito.times(1)).save(any())
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(TransactionStatusDto.CLOSED, viewArgumentCaptor.value.status)
       assertEquals(
         TransactionEventCode.TRANSACTION_CLOSED_EVENT,
@@ -1934,7 +1952,8 @@ class ClosePaymentHelperTests {
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       verify(transactionClosedEventRepository, Mockito.times(1)).save(any())
       verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(TransactionStatusDto.UNAUTHORIZED, viewArgumentCaptor.value.status)
       assertEquals(
         TransactionEventCode.TRANSACTION_CLOSURE_FAILED_EVENT,
@@ -2036,7 +2055,8 @@ class ClosePaymentHelperTests {
       verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(transactionsViewRepository, Mockito.times(1)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
 
       val expectedViewUpdateStatuses = listOf(TransactionStatusDto.REFUND_REQUESTED)
       val expectedEventsCodes = listOf(TransactionEventCode.TRANSACTION_REFUND_REQUESTED_EVENT)
@@ -2144,7 +2164,8 @@ class ClosePaymentHelperTests {
     verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
     verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
     verify(transactionsViewRepository, Mockito.times(0)).save(any())
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(updateTransactionStatusTracerUtils, times(1))
       .traceStatusUpdateOperation(
         ClosePaymentNodoStatusUpdate(
@@ -2239,7 +2260,8 @@ class ClosePaymentHelperTests {
     verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
     verify(transactionsViewRepository, Mockito.times(1)).save(any())
     verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
     assertEquals(
       TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT.name,
@@ -2337,7 +2359,8 @@ class ClosePaymentHelperTests {
     verify(transactionClosedEventRepository, Mockito.times(0)).save(any())
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
     verify(transactionsViewRepository, Mockito.times(1)).save(any())
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(updateTransactionStatusTracerUtils, times(1))
       .traceStatusUpdateOperation(
         ClosePaymentNodoStatusUpdate(
@@ -2434,7 +2457,7 @@ class ClosePaymentHelperTests {
 
     given(
         closureRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), anyOrNull()))
+          any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
 
     /* test */
@@ -2457,7 +2480,8 @@ class ClosePaymentHelperTests {
     verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
     verify(transactionsViewRepository, Mockito.times(0)).save(any())
 
-    verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(1))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     assertEquals(0, retryCountCaptor.value)
     verify(updateTransactionStatusTracerUtils, times(1))
       .traceStatusUpdateOperation(
@@ -2559,7 +2583,8 @@ class ClosePaymentHelperTests {
       verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(transactionsViewRepository, Mockito.times(2)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
 
       val expectedViewUpdateStatuses =
         listOf(
@@ -2677,7 +2702,8 @@ class ClosePaymentHelperTests {
       verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
       verify(transactionsViewRepository, Mockito.times(1)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
       assertEquals(
         TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT.name,
@@ -2775,7 +2801,8 @@ class ClosePaymentHelperTests {
       verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
       verify(transactionsViewRepository, Mockito.times(1)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
       assertEquals(
         TransactionEventCode.TRANSACTION_CLOSURE_ERROR_EVENT.name,
@@ -2876,7 +2903,8 @@ class ClosePaymentHelperTests {
     verify(transactionClosureErrorEventStoreRepository, Mockito.times(1)).save(any())
     verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
     verify(transactionsViewRepository, Mockito.times(2)).save(any())
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(refundQueueAsyncClient, times(1))
       .sendMessageWithResponse(any<QueueEvent<TransactionRefundRequestedEvent>>(), any(), any())
     verify(updateTransactionStatusTracerUtils, times(1))
@@ -2962,7 +2990,7 @@ class ClosePaymentHelperTests {
 
     given(
         closureRetryService.enqueueRetryEvent(
-          any(), retryCountCaptor.capture(), any(), anyOrNull()))
+          any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
       .willReturn(Mono.empty())
     val (expectedHttpErrorCode, expectedErrorDescription) =
       if (throwable is ClosePaymentErrorResponseException) {
@@ -2992,7 +3020,8 @@ class ClosePaymentHelperTests {
     verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
     verify(transactionsViewRepository, Mockito.times(1)).save(any())
 
-    verify(closureRetryService, times(1)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(1))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     assertEquals(0, retryCountCaptor.value)
     assertEquals(TransactionStatusDto.CLOSURE_ERROR, viewArgumentCaptor.value.status)
     assertEquals(
@@ -3095,7 +3124,8 @@ class ClosePaymentHelperTests {
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1)).save(any())
       verify(transactionsViewRepository, Mockito.times(2)).save(any())
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
 
       val expectedViewUpdateStatuses =
         listOf(TransactionStatusDto.CLOSED, TransactionStatusDto.REFUND_REQUESTED)
@@ -3183,7 +3213,7 @@ class ClosePaymentHelperTests {
           ClosePaymentResponseDto().apply { outcome = ClosePaymentResponseDto.OutcomeEnum.KO })
       given(
           closureRetryService.enqueueRetryEvent(
-            any(), retryCountCaptor.capture(), any(), anyOrNull()))
+            any(), retryCountCaptor.capture(), any(), anyOrNull(), anyOrNull()))
         .willReturn(Mono.empty())
       given(
           deadLetterTracedQueueAsyncClient.sendAndTraceDeadLetterQueueEvent(
@@ -3212,7 +3242,8 @@ class ClosePaymentHelperTests {
       verify(transactionsRefundedEventStoreRepository, Mockito.times(0)).save(any())
       verify(transactionsViewRepository, Mockito.times(2)).save(any())
 
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(deadLetterTracedQueueAsyncClient, times(1))
         .sendAndTraceDeadLetterQueueEvent(
           argThat<BinaryData> {
@@ -3324,7 +3355,8 @@ class ClosePaymentHelperTests {
           any()) // FIXME: Unable to use better argument captor because of misbehaviour in static
       // mocking
       verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
-      verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+      verify(closureRetryService, times(0))
+        .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
       verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
       assertEquals(TransactionStatusDto.CLOSED, viewArgumentCaptor.value.status)
       assertEquals(
@@ -3416,7 +3448,8 @@ class ClosePaymentHelperTests {
       .save(any()) // FIXME: Unable to use better argument captor because of misbehaviour in static
     // mocking
     verify(transactionsViewRepository, Mockito.times(1)).save(expectedUpdatedTransaction)
-    verify(closureRetryService, times(0)).enqueueRetryEvent(any(), any(), any(), anyOrNull())
+    verify(closureRetryService, times(0))
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
     verify(paymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never()).deleteById(any())
     assertEquals(TransactionStatusDto.CLOSED, viewArgumentCaptor.value.status)
     assertEquals(


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/225
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add tracing for error that occurs performing Node closePayment request.
<!--- Describe your changes in detail -->

#### Motivation and Context
Those errors will be used to communicate trace and communicate to touchpoint the specific Node error that happened in order to display the correct page to the user
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + locally using eCommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.