### PR TITLE
fix: clear closureErrorData in case of response received from Node

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -436,6 +436,8 @@ class ClosePaymentHelper(
               .flatMap { tx ->
                 tx.status = newStatus
                 tx.sendPaymentResultOutcome = sendPaymentResultOutcome
+                tx.closureErrorData =
+                  null // reset closure error state when a close payment response have been received
                 transactionsViewRepository.save(tx)
               }
               .thenReturn(closedEvent)
@@ -447,6 +449,8 @@ class ClosePaymentHelper(
               .flatMap { tx ->
                 tx.status = newStatus
                 tx.sendPaymentResultOutcome = sendPaymentResultOutcome
+                tx.closureErrorData =
+                  null // reset closure error state when a close payment response have been received
                 transactionsViewRepository.save(tx)
               }
               .thenReturn(closedEvent)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add clear of view "closureErrorData" in case of successful response received by Node during close payment retry
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to clear "closureErrorData" transaction-view section in the case the close payment retry process is performed successfully in a retry attempt
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.