### PR TITLE
[CHK-4372] Add canceled by user info into close payment data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,8 +638,8 @@
 				<configuration>
 					<skipCheckoutIfExists>false</skipCheckoutIfExists>
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-					<scmVersionType>tag</scmVersionType>
-					<scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+					<scmVersion>CHK-4371-add-wasCanceledByUserInfo</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<kotlinx-coroutines.version>1.10.2</kotlinx-coroutines.version>
 		<spring-cloud-azure.version>5.18.0</spring-cloud-azure.version>
 		<jacoco.version>0.8.11</jacoco.version>
-		<pagopa-ecommerce-commons.version>3.0.1</pagopa-ecommerce-commons.version>
+		<pagopa-ecommerce-commons.version>3.0.2</pagopa-ecommerce-commons.version>
 		<sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
 			**/it/pagopa/transactions/**,
 			**/it/pagopa/ecommerce/eventdispatcher/validation/**
@@ -638,8 +638,8 @@
 				<configuration>
 					<skipCheckoutIfExists>false</skipCheckoutIfExists>
 					<connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-					<scmVersionType>branch</scmVersionType>
-					<scmVersion>CHK-4371-add-wasCanceledByUserInfo</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
 					<goals>install -DskipTests</goals>
 				</configuration>
 				<executions>

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -394,11 +394,11 @@ class ClosePaymentHelper(
       if (!wasAuthorized && !canceledByUser) {
         Either.left(
           TransactionClosureFailedEvent(
-            transaction.transactionId.value(), TransactionClosureData(outcome)))
+            transaction.transactionId.value(), TransactionClosureData(outcome, canceledByUser)))
       } else {
         Either.right(
           TransactionClosedEvent(
-            transaction.transactionId.value(), TransactionClosureData(outcome)))
+            transaction.transactionId.value(), TransactionClosureData(outcome, canceledByUser)))
       }
 
     /*

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
@@ -545,7 +545,8 @@ class ClosePaymentHelperTests {
 
       val expectedClosureEvent =
         TransactionClosureFailedEvent(
-          activationEvent.transactionId, TransactionClosureData(TransactionClosureData.Outcome.OK))
+          activationEvent.transactionId,
+          TransactionClosureData(TransactionClosureData.Outcome.OK, false))
 
       /* preconditions */
       given(checkpointer.success()).willReturn(Mono.empty())


### PR DESCRIPTION
Add  info about user canceled request into closed event details

#### List of Changes

Update the `TransactionClosureData()` constructor

#### Motivation and Context

This patch is useful for ecommerce cdc service to make closed event processing indipendent from previous event query

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.