### PR TITLE
[CHK-4792] chore(openTelemetry): update openTelemetry java agent to version 2.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /app/
 ARG EXTRACTED=/workspace/app/target/extracted
 
 # OpenTelemetry agent
-ADD --chown=user https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.1.0/opentelemetry-javaagent.jar .
+ADD --chown=user https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.26.0/opentelemetry-javaagent.jar .
 
 COPY --from=build --chown=user ${EXTRACTED}/dependencies/ ./
 RUN true


### PR DESCRIPTION
#### List of Changes

- Updated OpenTelemetry Java agent to version 2.26.0

#### Motivation and Context

The goal is to remove the OpenTelemetry spans containing `redis.encode.start`/`redis.encode.end`, written on every Redis operation. This is done updating the java agent version to one greater than `2.21.0`, where these have been filtered out (see https://github.com/elastic/elastic-otel-java/issues/796) . 

#### How Has This Been Tested?
- DEV deploy

#### Screenshots (if appropriate):

<img width="2243" height="838" alt="image" src="https://github.com/user-attachments/assets/38d1d835-75d9-4bb3-ae52-5d5ef4665f33" />

&nbsp;

<img width="2243" height="844" alt="image" src="https://github.com/user-attachments/assets/bf6f8e73-7e25-4360-882f-ca36c2158562" />



#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.