### PR TITLE
fix: skip close payment event processing in case of already processed transaction

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -183,16 +183,19 @@ class ClosePaymentHelper(
       baseTransaction
         .flatMap {
           logger.info("Status for transaction ${it.transactionId.value()}: ${it.status}")
-
+          if (it is BaseTransactionClosed) {
+            logger.info(
+              "Close payment already processed for transaction with id ${it.transactionId.value()}, skipping event")
+            return@flatMap Mono.empty()
+          }
           if (!closureRequestedValidStatuses.contains(it.status)) {
-            Mono.error(
+            return@flatMap Mono.error(
               BadTransactionStatusException(
                 transactionId = it.transactionId,
                 expected = closureRequestedValidStatuses.toList(),
                 actual = it.status))
-          } else {
-            Mono.just(it)
           }
+          Mono.just(it)
         }
         .flatMap { tx ->
           val closePaymentTransactionData =

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelperTests.kt
@@ -6552,4 +6552,70 @@ class ClosePaymentHelperTests {
 
     return transactionTracingSpy
   }
+
+  @ParameterizedTest
+  @EnumSource(TransactionClosureData.Outcome::class)
+  fun `consumer skip event processing for transaction which close payment have already been processed`(
+    closePaymentOutcome: TransactionClosureData.Outcome
+  ) = runTest {
+    whenever(mockedEnv.getProperty(ENV_TRANSACTIONS_VIEW_UPDATED_ENABLED_FLAG, "true"))
+      .thenReturn("true")
+    val activationEvent = transactionActivateEvent() as TransactionEvent<Any>
+    val authorizationRequestEvent =
+      transactionAuthorizationRequestedEvent() as TransactionEvent<Any>
+    val authorizationCompleteEvent =
+      transactionAuthorizationCompletedEvent(
+        NpgTransactionGatewayAuthorizationData(
+          OperationResultDto.EXECUTED, "operationId", "paymentEnd2EndId", null, null))
+        as TransactionEvent<Any>
+    val closureRequestedEvent = transactionClosureRequestedEvent() as TransactionEvent<Any>
+    val closedEvent = transactionClosedEvent(closePaymentOutcome) as TransactionEvent<Any>
+
+    val events =
+      listOf(
+        activationEvent,
+        authorizationRequestEvent,
+        authorizationCompleteEvent,
+        closureRequestedEvent,
+        closedEvent)
+
+    /* preconditions */
+    given(checkpointer.success()).willReturn(Mono.empty())
+    given(
+        transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID))
+      .willReturn(events.toFlux())
+
+    /* test */
+
+    StepVerifier.create(
+        closePaymentHelper.closePayment(
+          ClosePaymentEvent.requested(
+            QueueEvent(
+              closureRequestedEvent as TransactionClosureRequestedEvent, MOCK_TRACING_INFO)),
+          checkpointer,
+          EmptyTransaction()))
+      .expectNext(Unit)
+      .verifyComplete()
+
+    /* Asserts */
+    verify(checkpointer, Mockito.times(1)).success()
+    verify(nodeService, never()).closePayment(any(), any())
+    verify(refundQueueAsyncClient, never())
+      .sendMessageWithResponse(any<QueueEvent<TransactionRefundRequestedEvent>>(), any(), any())
+    verify(reactivePaymentRequestInfoRedisTemplateWrapper, Mockito.after(1000).never())
+      .deleteById(any())
+    verify(transactionClosureErrorEventStoreRepository, never()).save(any())
+    verify(transactionClosedEventRepository, never()).save(any())
+    verify(transactionsRefundedEventStoreRepository, never()).save(any())
+    verify(transactionsViewRepository, never()).save(any())
+    verify(closureRetryService, never())
+      .enqueueRetryEvent(any(), any(), any(), anyOrNull(), anyOrNull())
+
+    verify(updateTransactionStatusTracerUtils, never()).traceStatusUpdateOperation(any())
+
+    verify(transactionTracing, never())
+      .addSpanAttributesCanceledOrUnauthorizedFlowFromTransaction(any(), any())
+    verify(mockOpenTelemetryUtils, never())
+      .addSpanWithAttributes(eq(TransactionTracing::class.simpleName), any())
+  }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
add logic to skip duplicate event processing in case of retry on the closure requested event
<!--- Describe your changes in detail -->

#### Motivation and Context
Since pagopa-ecommerce-transactions-service PATCH auth-requests can be invoked multiple times rewriting event in case of subsequent invocations where closure requested event have not already been processed this can cause of multiple closure requested event being processed.
In case of event re-write the second event is written with a visibility timeout by transactions-service
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.