### PR TITLE
fix: [DB optimization] - review query to reduce avoid unuseful queries

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionExpirationQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionExpirationQueueConsumer.kt
@@ -67,10 +67,11 @@ class TransactionExpirationQueueConsumer(
     val transactionId = queueEvent.fold({ it.event.transactionId }, { it.event.transactionId })
     val events =
       Flux.defer {
-        transactionsEventStoreRepository
-          .findByTransactionIdOrderByCreationDateAsc(transactionId)
-          .map { it as TransactionEvent<Any> }
-      }
+          transactionsEventStoreRepository
+            .findByTransactionIdOrderByCreationDateAsc(transactionId)
+            .map { it as TransactionEvent<Any> }
+        }
+        .cache()
     val baseTransaction = reduceEvents(events)
     val refundPipeline =
       baseTransaction

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsQueueConsumer.kt
@@ -72,6 +72,7 @@ class TransactionNotificationsQueueConsumer(
       transactionsEventStoreRepository
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
         .map { it as TransactionEvent<Any> }
+        .cache()
 
     val baseTransaction = reduceEvents(events, EmptyTransaction())
 

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionNotificationsRetryQueueConsumer.kt
@@ -87,6 +87,7 @@ class TransactionNotificationsRetryQueueConsumer(
       transactionsEventStoreRepository
         .findByTransactionIdOrderByCreationDateAsc(transactionId)
         .map { it as TransactionEvent<Any> }
+        .cache()
     val baseTransaction = reduceEvents(events, EmptyTransaction())
 
     val notificationResendPipeline =

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionRefundRetryQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionRefundRetryQueueConsumer.kt
@@ -57,8 +57,9 @@ class TransactionRefundRetryQueueConsumer(
     val tracingInfo = parsedEvent.tracingInfo
 
     val events =
-      transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(
-        event.transactionId)
+      transactionsEventStoreRepository
+        .findByTransactionIdOrderByCreationDateAsc(event.transactionId)
+        .cache()
 
     val baseTransaction =
       events.reduce(EmptyTransaction(), Transaction::applyEvent).cast(BaseTransaction::class.java)

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundQueueConsumer.kt
@@ -68,7 +68,9 @@ class TransactionsRefundQueueConsumer(
     val transactionId = getTransactionIdFromPayload(event)
 
     val events =
-      transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId)
+      transactionsEventStoreRepository
+        .findByTransactionIdOrderByCreationDateAsc(transactionId)
+        .cache()
 
     val refundPipeline =
       events

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -878,9 +878,10 @@ fun reduceEvents(
 ): Mono<BaseTransaction> =
   reduceEvents(
     transactionId.flatMapMany {
-      transactionsEventStoreRepository.findByTransactionIdOrderByCreationDateAsc(it).map {
-        it as TransactionEvent<Any>
-      }
+      transactionsEventStoreRepository
+        .findByTransactionIdOrderByCreationDateAsc(it)
+        .map { it as TransactionEvent<Any> }
+        .cache()
     },
     emptyTransaction)
 

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -953,8 +953,7 @@ private fun updateNotifiedTransactionStatus(
           lastProcessedEventAt = ZonedDateTime.parse(event.creationDate).toInstant().toEpochMilli()
         }
       })
-    .flatMap { transactionUserReceiptRepository.insert(event) }
-    .thenReturn(event)
+    .then(transactionUserReceiptRepository.insert(event))
 }
 
 /*

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuthorizationRequestedHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/AuthorizationRequestedHelper.kt
@@ -3,19 +3,21 @@ package it.pagopa.ecommerce.eventdispatcher.queues.v2.helpers
 import com.azure.core.util.BinaryData
 import com.azure.spring.messaging.checkpoint.Checkpointer
 import com.azure.storage.queue.QueueAsyncClient
-import it.pagopa.ecommerce.commons.documents.v2.*
+import it.pagopa.ecommerce.commons.documents.v2.TransactionAuthorizationOutcomeWaitingEvent
+import it.pagopa.ecommerce.commons.documents.v2.TransactionAuthorizationRequestData
+import it.pagopa.ecommerce.commons.documents.v2.TransactionAuthorizationRequestedEvent
 import it.pagopa.ecommerce.commons.documents.v2.authorization.NpgTransactionGatewayAuthorizationRequestedData
 import it.pagopa.ecommerce.commons.domain.v2.EmptyTransaction
 import it.pagopa.ecommerce.commons.domain.v2.Transaction
-import it.pagopa.ecommerce.commons.domain.v2.pojos.*
+import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransactionWithRequestedAuthorization
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
 import it.pagopa.ecommerce.commons.queues.QueueEvent
 import it.pagopa.ecommerce.commons.queues.StrictJsonSerializerProvider
 import it.pagopa.ecommerce.commons.queues.TracingUtils
 import it.pagopa.ecommerce.eventdispatcher.client.TransactionsServiceClient
 import it.pagopa.ecommerce.eventdispatcher.client.UserStatsServiceClient
-import it.pagopa.ecommerce.eventdispatcher.exceptions.*
-import it.pagopa.ecommerce.eventdispatcher.queues.v2.*
+import it.pagopa.ecommerce.eventdispatcher.queues.v2.handleGetStateByPatchTransactionService
+import it.pagopa.ecommerce.eventdispatcher.queues.v2.runTracedPipelineWithDeadLetterQueue
 import it.pagopa.ecommerce.eventdispatcher.repositories.TransactionsEventStoreRepository
 import it.pagopa.ecommerce.eventdispatcher.services.eventretry.v2.AuthorizationStateRetrieverRetryService
 import it.pagopa.ecommerce.eventdispatcher.services.v2.AuthorizationStateRetrieverService
@@ -104,6 +106,7 @@ class AuthorizationRequestedHelper(
         .reduce(EmptyTransaction(), Transaction::applyEvent)
         .filter { it is BaseTransactionWithRequestedAuthorization }
         .cast(BaseTransactionWithRequestedAuthorization::class.java)
+        .cache()
     val getStateThresholdDate =
       authorizationRequestedDate + Duration.ofSeconds(firstAttemptDelaySeconds.toLong())
     val now = OffsetDateTime.now()
@@ -202,6 +205,7 @@ class AuthorizationRequestedHelper(
         .reduce(EmptyTransaction(), Transaction::applyEvent)
         .filter { it is BaseTransactionWithRequestedAuthorization }
         .cast(BaseTransactionWithRequestedAuthorization::class.java)
+        .cache()
 
     val authorizationRequestedPipeline =
       transaction

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/helpers/ClosePaymentHelper.kt
@@ -189,7 +189,7 @@ class ClosePaymentHelper(
               logger.info("Transaction with id {} skip close payment: {}", transactionId, !it)
             }
         }
-        .flatMap { reduceEvents(events, emptyTransaction) }
+        .flatMap { baseTransaction }
         .flatMap {
           logger.info("Status for transaction ${it.transactionId.value()}: ${it.status}")
 

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RetryEventService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RetryEventService.kt
@@ -101,7 +101,7 @@ abstract class RetryEventService<E>(
                   ZonedDateTime.parse(event.creationDate).toInstant().toEpochMilli()
               }
             })
-          .flatMap { Mono.just(event) }
+          .thenReturn(event)
       }
 
   private fun enqueueMessage(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TransactionsViewProjectionHandler.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/utils/TransactionsViewProjectionHandler.kt
@@ -34,10 +34,13 @@ object TransactionsViewProjectionHandler {
         .cast(Transaction::class.java)
         .map(viewUpdater)
 
-    return updatedTransactionView
-      .filter { _ -> saveEvent }
-      .cast(BaseTransactionView::class.java)
-      .flatMap(transactionsViewRepository::save)
-      .switchIfEmpty(updatedTransactionView)
+    return if (saveEvent) {
+      updatedTransactionView
+        .cast(BaseTransactionView::class.java)
+        .flatMap(transactionsViewRepository::save)
+        .switchIfEmpty(updatedTransactionView)
+    } else {
+      Mono.empty()
+    }
   }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/AuthorizationStateRetrieverRetryServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/AuthorizationStateRetrieverRetryServiceTest.kt
@@ -6,7 +6,10 @@ import com.azure.core.util.BinaryData
 import com.azure.core.util.serializer.TypeReference
 import com.azure.storage.queue.QueueAsyncClient
 import com.azure.storage.queue.models.SendMessageResult
-import it.pagopa.ecommerce.commons.documents.v2.*
+import it.pagopa.ecommerce.commons.documents.v2.BaseTransactionRetriedData
+import it.pagopa.ecommerce.commons.documents.v2.Transaction
+import it.pagopa.ecommerce.commons.documents.v2.TransactionAuthorizationOutcomeWaitingEvent
+import it.pagopa.ecommerce.commons.documents.v2.TransactionEvent
 import it.pagopa.ecommerce.commons.domain.v2.TransactionEventCode
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto
 import it.pagopa.ecommerce.commons.queues.QueueEvent
@@ -473,6 +476,8 @@ class AuthorizationStateRetrieverRetryServiceTest {
         authRequestedOutcomeWaitingQueueAsyncClient.sendMessageWithResponse(
           queueCaptor.capture(), durationCaptor.capture(), anyOrNull()))
       .willReturn(queueSuccessfulResponse())
+    given(mockedEnv.getProperty(ENV_TRANSACTIONS_VIEW_UPDATED_ENABLED_FLAG, "true"))
+      .willReturn("true")
     StepVerifier.create(
         authorizationStateRetrieverRetryService.enqueueRetryEvent(
           baseTransaction, maxAttempts - 1, TracingInfoTest.MOCK_TRACING_INFO))

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/ClosureRetryServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/ClosureRetryServiceTests.kt
@@ -376,6 +376,8 @@ class ClosureRetryServiceTests {
         closureRetryQueueAsyncClient.sendMessageWithResponse(
           queueCaptor.capture(), durationCaptor.capture(), anyOrNull()))
       .willReturn(queueSuccessfulResponse())
+    given(mockedEnv.getProperty(ENV_TRANSACTIONS_VIEW_UPDATED_ENABLED_FLAG, "true"))
+      .willReturn("true")
     StepVerifier.create(
         closureRetryService.enqueueRetryEvent(baseTransaction, maxAttempts - 1, MOCK_TRACING_INFO))
       .expectError(java.lang.RuntimeException::class.java)

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/NotificationRetryServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/NotificationRetryServiceTests.kt
@@ -473,6 +473,8 @@ class NotificationRetryServiceTests {
         notificationRetryQueueAsyncClient.sendMessageWithResponse(
           queueCaptor.capture(), durationCaptor.capture(), anyOrNull()))
       .willReturn(queueSuccessfulResponse())
+    given(mockedEnv.getProperty(ENV_TRANSACTIONS_VIEW_UPDATED_ENABLED_FLAG, "true"))
+      .willReturn("true")
     StepVerifier.create(
         notificationRetryService.enqueueRetryEvent(
           baseTransaction, maxAttempts - 1, MOCK_TRACING_INFO))

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RefundRetryServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/services/eventretry/v2/RefundRetryServiceTests.kt
@@ -458,6 +458,8 @@ class RefundRetryServiceTests {
     given(transactionsViewRepository.save(viewRepositoryCaptor.capture())).willAnswer {
       Mono.just(it.arguments[0])
     }
+    given(mockedEnv.getProperty(ENV_TRANSACTIONSVIEW_UPDATED_ENABLED_FLAG, "true"))
+      .willReturn("true")
     given(
         refundRetryQueueAsyncClient.sendMessageWithResponse(
           queueCaptor.capture(), durationCaptor.capture(), anyOrNull()))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- use cache() method to avoid one query to be executed for each mono subscribe
- refactor logic to avoid useless transactions-view find query in case ff for save view is disabled
<!--- Describe your changes in detail -->

#### Motivation and Context
- Cold mono causes one query to be executed per subscription, resulting in multiple find query being done for the same event processing
- transactions-view can be fetched only in cases where service have to update it too, that is, when ff for sync view update is enabled
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
local test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.