### PR TITLE
fix: [PIDM-2191] Use paymentTypeCode for PaymentMethod instead of name

### DIFF
--- a/dep-sha256.json
+++ b/dep-sha256.json
@@ -1331,11 +1331,11 @@
       "sha256": "Hh5CfDb_Y8RP0w7yktnnc-oxVEYKtiZdP-1-b1vFD7k="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.9.0",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
-      "sha256": "iE9aid_2YF5vGHvOrod9K7Gk6Lnw2zuRJA7Y4gJ3UA8="
+      "version": "3.9.0",
+      "sha256": "Y6_BCEWtaphqnJFqM1zKgw06F_Fv0v5pWSJ0Uclf7t0="
     },
     {
       "id": "org.springframework.boot:spring-boot-starter-web-services:jar:3.4.5",
@@ -1443,13 +1443,6 @@
       "sha256": "QUgzJyhJDO8Ssp2sTDhfRpgvBChRMsb6Ua1yZ9fceos="
     },
     {
-      "id": "commons-lang:commons-lang:jar:2.6",
-      "artifactId": "commons-lang",
-      "groupId": "commons-lang",
-      "version": "2.6",
-      "sha256": "UPEbCfh3wpTVbyRGP0fSj5Kc9QRPZIZhwPDPuumi9Jw="
-    },
-    {
       "id": "io.opentelemetry.instrumentation:opentelemetry-reactor-3.1:jar:2.4.0-alpha",
       "artifactId": "opentelemetry-reactor-3.1",
       "groupId": "io.opentelemetry.instrumentation",
@@ -1520,11 +1513,11 @@
       "sha256": "AkrT4OPFxXXeSRjo0CCtSv9NtDVjRcDXULlAC5irzZE="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.9.0",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
-      "sha256": "n7kv5ZA7u0RlPDQehf83z4Tp4UEwMboQgucEj6Xut9A="
+      "version": "3.9.0",
+      "sha256": "bZISyIWoxtMC6KhPj7rbt88-bz4zYO2tm6HZFgR1rzk="
     },
     {
       "id": "com.squareup.okhttp3:okhttp:jar:5.3.2",

--- a/dep-sha256.json
+++ b/dep-sha256.json
@@ -1331,11 +1331,11 @@
       "sha256": "Hh5CfDb_Y8RP0w7yktnnc-oxVEYKtiZdP-1-b1vFD7k="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0",
+      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0",
-      "sha256": "Yv-MOKcTkPf_jgoVZnktlBkThfBAzzCR8eQ7tX2q76I="
+      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "sha256": "iE9aid_2YF5vGHvOrod9K7Gk6Lnw2zuRJA7Y4gJ3UA8="
     },
     {
       "id": "org.springframework.boot:spring-boot-starter-web-services:jar:3.4.5",
@@ -1520,11 +1520,11 @@
       "sha256": "AkrT4OPFxXXeSRjo0CCtSv9NtDVjRcDXULlAC5irzZE="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0",
+      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0",
-      "sha256": "LsJGsMZ7DZ_tvKuvM-B5uZFqP0dUnJC5VOAbpxKaPU4="
+      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "sha256": "n7kv5ZA7u0RlPDQehf83z4Tp4UEwMboQgucEj6Xut9A="
     },
     {
       "id": "com.squareup.okhttp3:okhttp:jar:5.3.2",

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <kotlinx-coroutines.version>1.10.2</kotlinx-coroutines.version>
         <spring-cloud-azure.version>5.18.0</spring-cloud-azure.version>
         <jacoco.version>0.8.11</jacoco.version>
-        <pagopa-ecommerce-commons.version>3.8.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd</pagopa-ecommerce-commons.version>
         <sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
             **/it/pagopa/transactions/**,
             **/it/pagopa/ecommerce/eventdispatcher/validation/**

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <kotlinx-coroutines.version>1.10.2</kotlinx-coroutines.version>
         <spring-cloud-azure.version>5.18.0</spring-cloud-azure.version>
         <jacoco.version>0.8.11</jacoco.version>
-        <pagopa-ecommerce-commons.version>3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>3.9.0</pagopa-ecommerce-commons.version>
         <sonar.coverage.exclusions> <!-- the members of the following list should be in the same line -->
             **/it/pagopa/transactions/**,
             **/it/pagopa/ecommerce/eventdispatcher/validation/**

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/common.kt
@@ -292,8 +292,8 @@ fun retrieveAuthorizationState(
               as NpgTransactionGatewayActivationData)
             .correlationId,
         paymentMethod =
-          NpgClient.PaymentMethod.valueOf(
-            transaction.transactionAuthorizationRequestData.paymentMethodName))
+          NpgClient.PaymentMethod.fromMethodTypeCode(
+            transaction.transactionAuthorizationRequestData.paymentTypeCode))
     }
 }
 
@@ -793,8 +793,8 @@ private fun refundTransactionNPG(
               as NpgTransactionGatewayActivationData)
             .correlationId,
         paymentMethod =
-          NpgClient.PaymentMethod.valueOf(
-            transaction.transactionAuthorizationRequestData.paymentMethodName))
+          NpgClient.PaymentMethod.fromMethodTypeCode(
+            transaction.transactionAuthorizationRequestData.paymentTypeCode))
       .map { refundResponse -> Pair(refundResponse, transaction) }
       .onErrorMap({ e -> e is BadGatewayException || e is NpgResponseException }) { e ->
         logger.error(

--- a/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/AuthorizationStateRetrieverService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/eventdispatcher/services/v2/AuthorizationStateRetrieverService.kt
@@ -80,8 +80,8 @@ class AuthorizationStateRetrieverService(
           transactionId = trx.transactionId,
           pspId = transaction.transactionAuthorizationRequestData.pspId,
           paymentMethod =
-            NpgClient.PaymentMethod.valueOf(
-              transaction.transactionAuthorizationRequestData.paymentMethodName),
+            NpgClient.PaymentMethod.fromMethodTypeCode(
+              transaction.transactionAuthorizationRequestData.paymentTypeCode),
           orderId = orderId,
           correlationId = correlationId)
       }

--- a/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/eventdispatcher/queues/v2/TransactionsRefundEventsConsumerTests.kt
@@ -295,7 +295,8 @@ class TransactionsRefundEventsConsumerTests {
           pspId = expectedPspId,
           correlationId = correlationId,
           paymentMethod =
-            NpgClient.PaymentMethod.valueOf(authorizationRequestEvent.data.paymentMethodName))
+            NpgClient.PaymentMethod.fromMethodTypeCode(
+              authorizationRequestEvent.data.paymentTypeCode))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1))
         .insert(refundEventStoreCaptor.capture())
       verify(refundRetryService, times(1))
@@ -402,7 +403,8 @@ class TransactionsRefundEventsConsumerTests {
           pspId = expectedPspId,
           correlationId = correlationId,
           paymentMethod =
-            NpgClient.PaymentMethod.valueOf(authorizationRequestEvent.data.paymentMethodName))
+            NpgClient.PaymentMethod.fromMethodTypeCode(
+              authorizationRequestEvent.data.paymentTypeCode))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1))
         .insert(refundEventStoreCaptor.capture())
       verify(refundRetryService, times(0))
@@ -512,7 +514,8 @@ class TransactionsRefundEventsConsumerTests {
           pspId = expectedPspId,
           correlationId = correlationId,
           paymentMethod =
-            NpgClient.PaymentMethod.valueOf(authorizationRequestEvent.data.paymentMethodName))
+            NpgClient.PaymentMethod.fromMethodTypeCode(
+              authorizationRequestEvent.data.paymentTypeCode))
       verify(transactionsRefundedEventStoreRepository, Mockito.times(1))
         .insert(refundEventStoreCaptor.capture())
       verify(refundRetryService, times(0))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Updated NPG payment method mapping to use `paymentTypeCode` instead of `paymentMethodName`

#### Motivation and Context

The previous approach resolved the NPG payment method from the `paymentMethodName` field using `valueOf()`. This change aligns with the new `ecommerce-commons` library method `fromMethodTypeCode()`, which maps the payment method via `paymentTypeCode` — a more reliable and consistent identifier for NPG payment method resolution (PIDM-2191).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.