### PR TITLE
feat: [PIDM-2332] migrate openapi linter to spectral

### DIFF
--- a/.github/actions/openapi-lint/README.md
+++ b/.github/actions/openapi-lint/README.md
@@ -1,0 +1,41 @@
+# OpenAPI lint
+
+Lints an OpenAPI spec with [Spectral](https://github.com/stoplightio/spectral) and fails the job on findings at or above a given severity. Replaces `zuplo/rmoa-action`, which depends on a cloud API key and only exposes numeric thresholds, with no way to disable a single rule.
+
+The rules live in the repository, in `.spectral.yaml`.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+- name: OpenAPI lint - ${{ matrix.spec.version }}
+  uses: ./.github/actions/openapi-lint
+  with:
+    spec_path: ${{ matrix.spec.path }}
+```
+
+The spec matrix stays in the calling workflow, because the number of specs differs per repository.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `spec_path` | yes | | Path to the OpenAPI spec, relative to the repository root |
+| `ruleset` | no | `.spectral.yaml` | Path to the Spectral ruleset |
+| `fail_severity` | no | `warn` | Lowest severity that fails the job: `error`, `warn` or `info` |
+| `fail_on_violation` | no | `true` | Set to `false` for a report-only rollout |
+| `spectral_version` | no | `6.16.3` | Version of `@stoplight/spectral-cli` |
+| `owasp_ruleset_version` | no | `2.0.1` | Version of `@stoplight/spectral-owasp-ruleset` |
+
+## Behaviour worth knowing
+
+**A lint that cannot run fails the job, in report-only mode too.** Spectral exits `1` when it finds results but `2` or more when it could not run at all, and in that case it writes no report. A gate that does not tell the two apart passes silently and stops protecting anything. An unloadable ruleset is a configuration error, not a finding, so `fail_on_violation: false` does not suppress it.
+
+Two cases need more than the exit code, since Spectral reports them as ordinary findings: an unrecognised document yields exit `0` and one `unrecognized-format` **warning** having run no rules, and an unparseable spec yields `parser` findings. Both are configuration errors, so neither `fail_severity` nor `fail_on_violation` suppresses them.
+
+**Noise is handled by severity, not by a budget.** There is deliberately no `max_warnings`. A rule too noisy to block on is downgraded in `.spectral.yaml`, by name and with the reason, so the exception is visible in review; a numeric budget hides findings by count and, as the RMOA rollout showed, only ever grows. Use `fail_severity: error` to let a repository migrate while its warnings are still being worked through, and `fail_on_violation: false` when nothing should block yet.
+
+**Only errors and warnings are annotated on the pull request.** GitHub renders at most 10 annotations per type per step, so annotating info findings as well would push the actionable ones out of the view. Info findings are reported as counts, broken down by rule, in the job summary.
+
+**The npm packages are installed next to the ruleset.** Spectral resolves the packages a ruleset extends starting from the directory of the ruleset file, and these repositories have no `package.json`. The install therefore targets `dirname(ruleset)` and creates only a `node_modules` directory, which is already ignored by git.

--- a/.github/actions/openapi-lint/action.yml
+++ b/.github/actions/openapi-lint/action.yml
@@ -14,16 +14,13 @@ inputs:
     default: "warn"
     description: >
       Lowest severity that fails the job: error, warn or info. Findings below it are
-      reported but never block. A rule too noisy to block on is downgraded by name in
-      the ruleset, where the exception is visible in review, rather than absorbed by a
-      numeric budget that hides findings by count and only ever grows.
+      reported but never block. Downgrade a noisy rule by name in the ruleset, not here.
   fail_on_violation:
     required: false
     default: "true"
     description: >
-      Fail the job when a threshold is exceeded. Set to false to run in report-only mode.
-      A lint that cannot run at all fails the job regardless, since it is a configuration
-      error rather than a finding.
+      Fail the job on blocking findings. Set to false for report-only. A lint that cannot
+      run fails regardless: that is a configuration error, not a finding.
   spectral_version:
     required: false
     default: "6.16.3"
@@ -43,9 +40,8 @@ runs:
         SPECTRAL_VERSION: ${{ inputs.spectral_version }}
         OWASP_RULESET_VERSION: ${{ inputs.owasp_ruleset_version }}
       run: |
-        # Spectral resolves the npm packages a ruleset extends from the directory of the
-        # ruleset file itself, and these repositories have no package.json, so the
-        # packages are installed there rather than in the working directory.
+        # Spectral resolves a ruleset's npm packages from the ruleset's own directory, and
+        # these repos have no package.json, so install there.
         npm install --no-save --no-package-lock --prefix "$(dirname "$RULESET")" \
           "@stoplight/spectral-cli@${SPECTRAL_VERSION}" \
           "@stoplight/spectral-owasp-ruleset@${OWASP_RULESET_VERSION}"
@@ -53,8 +49,7 @@ runs:
     - name: Lint ${{ inputs.spec_path }}
       shell: bash
       env:
-        # Every value reaches the script as an environment variable and none is
-        # interpolated into the script itself, so nothing can be spliced into the shell.
+        # Values reach the script as env vars, never interpolated into the run block.
         ACTION_PATH: ${{ github.action_path }}
         SPEC_PATH: ${{ inputs.spec_path }}
         RULESET: ${{ inputs.ruleset }}

--- a/.github/actions/openapi-lint/action.yml
+++ b/.github/actions/openapi-lint/action.yml
@@ -1,0 +1,63 @@
+name: OpenAPI lint
+description: "Lint an OpenAPI spec with Spectral and fail the job on findings at or above a severity"
+
+inputs:
+  spec_path:
+    required: true
+    description: Path to the OpenAPI spec to lint, relative to the repository root
+  ruleset:
+    required: false
+    default: ".spectral.yaml"
+    description: Path to the Spectral ruleset, relative to the repository root
+  fail_severity:
+    required: false
+    default: "warn"
+    description: >
+      Lowest severity that fails the job: error, warn or info. Findings below it are
+      reported but never block. A rule too noisy to block on is downgraded by name in
+      the ruleset, where the exception is visible in review, rather than absorbed by a
+      numeric budget that hides findings by count and only ever grows.
+  fail_on_violation:
+    required: false
+    default: "true"
+    description: >
+      Fail the job when a threshold is exceeded. Set to false to run in report-only mode.
+      A lint that cannot run at all fails the job regardless, since it is a configuration
+      error rather than a finding.
+  spectral_version:
+    required: false
+    default: "6.16.3"
+    description: Version of @stoplight/spectral-cli to install
+  owasp_ruleset_version:
+    required: false
+    default: "2.0.1"
+    description: Version of @stoplight/spectral-owasp-ruleset to install
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Spectral and the OWASP ruleset
+      shell: bash
+      env:
+        RULESET: ${{ inputs.ruleset }}
+        SPECTRAL_VERSION: ${{ inputs.spectral_version }}
+        OWASP_RULESET_VERSION: ${{ inputs.owasp_ruleset_version }}
+      run: |
+        # Spectral resolves the npm packages a ruleset extends from the directory of the
+        # ruleset file itself, and these repositories have no package.json, so the
+        # packages are installed there rather than in the working directory.
+        npm install --no-save --no-package-lock --prefix "$(dirname "$RULESET")" \
+          "@stoplight/spectral-cli@${SPECTRAL_VERSION}" \
+          "@stoplight/spectral-owasp-ruleset@${OWASP_RULESET_VERSION}"
+
+    - name: Lint ${{ inputs.spec_path }}
+      shell: bash
+      env:
+        # Every value reaches the script as an environment variable and none is
+        # interpolated into the script itself, so nothing can be spliced into the shell.
+        ACTION_PATH: ${{ github.action_path }}
+        SPEC_PATH: ${{ inputs.spec_path }}
+        RULESET: ${{ inputs.ruleset }}
+        FAIL_SEVERITY: ${{ inputs.fail_severity }}
+        FAIL_ON_VIOLATION: ${{ inputs.fail_on_violation }}
+      run: bash "${ACTION_PATH}/openapi-lint.sh"

--- a/.github/actions/openapi-lint/openapi-lint.sh
+++ b/.github/actions/openapi-lint/openapi-lint.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Lints an OpenAPI spec with Spectral and gates the job on the severity of the findings.
+# Inputs arrive as environment variables, see action.yml.
+set -euo pipefail
+
+: "${SPEC_PATH:?SPEC_PATH is required}"
+: "${RULESET:?RULESET is required}"
+: "${FAIL_SEVERITY:?FAIL_SEVERITY is required}"
+: "${FAIL_ON_VIOLATION:?FAIL_ON_VIOLATION is required}"
+
+# Spectral's own severity numbering, as it appears in the JSON report.
+case "$FAIL_SEVERITY" in
+  error) FAIL_LEVEL=0 ;;
+  warn)  FAIL_LEVEL=1 ;;
+  info)  FAIL_LEVEL=2 ;;
+  *)
+    echo "::error::fail_severity must be error, warn or info, got '${FAIL_SEVERITY}'"
+    exit 1
+    ;;
+esac
+
+SPECTRAL_BIN="${SPECTRAL_BIN:-$(dirname "$RULESET")/node_modules/.bin/spectral}"
+
+if [ ! -f "$SPEC_PATH" ]; then
+  echo "::error::OpenAPI spec not found: ${SPEC_PATH}"
+  exit 1
+fi
+if [ ! -f "$RULESET" ]; then
+  echo "::error::Spectral ruleset not found: ${RULESET}"
+  exit 1
+fi
+
+OUT="$(mktemp)"
+trap 'rm -f "$OUT"' EXIT
+
+# Exit 2 or more means Spectral could not run and wrote no JSON. Check both the exit code
+# and a non-empty report, or the gate passes silently and stops checking.
+set +e
+"$SPECTRAL_BIN" lint --ruleset "$RULESET" --format json --output "$OUT" --quiet "$SPEC_PATH"
+RC=$?
+set -e
+
+if [ "$RC" -gt 1 ] || [ ! -s "$OUT" ]; then
+  echo "::error file=${SPEC_PATH}::Spectral could not lint ${SPEC_PATH} (exit ${RC}): unloadable ruleset or unparseable spec. Failing the job rather than reporting a clean run."
+  exit 1
+fi
+
+# Both mean nothing was linted, yet Spectral reports them as ordinary findings:
+# unrecognized-format runs zero rules and is only a warning, so fail_severity: error
+# would let it through. Configuration errors, so report-only does not suppress them.
+UNLINTABLE=$(jq -r '[.[] | select(.code == "unrecognized-format" or .code == "parser")] | .[0].message // empty' "$OUT")
+if [ -n "$UNLINTABLE" ]; then
+  echo "::error file=${SPEC_PATH}::Spectral could not lint ${SPEC_PATH}: ${UNLINTABLE}. Failing the job rather than reporting a clean run."
+  exit 1
+fi
+
+count_severity() {
+  jq --argjson s "$1" '[.[] | select(.severity == $s)] | length' "$OUT"
+}
+blocking() {
+  if [ "$1" -le "$FAIL_LEVEL" ]; then echo "yes"; else echo "no"; fi
+}
+ERRORS=$(count_severity 0)
+WARNINGS=$(count_severity 1)
+INFOS=$(count_severity 2)
+
+# Computed here, not delegated to Spectral's --fail-severity: report-only would then have
+# to swallow Spectral's exit code, reopening the exit 2 hole above.
+BLOCKING=$(jq --argjson l "$FAIL_LEVEL" '[.[] | select(.severity <= $l)] | length' "$OUT")
+
+# Errors and warnings only: GitHub renders at most 10 annotations per type per step, so
+# info findings would bury them. Info goes to the job summary as counts.
+jq -r --arg f "$SPEC_PATH" '
+  .[]
+  | select(.severity <= 1)
+  | "::\(if .severity == 0 then "error" else "warning" end) title=\(.code),file=\($f),line=\(.range.start.line + 1),endLine=\(.range.end.line + 1),col=\(.range.start.character + 1)::\(.message | gsub("\n"; " "))"
+' "$OUT"
+
+echo "${SPEC_PATH}: ${ERRORS} error(s), ${WARNINGS} warning(s), ${INFOS} info; ${BLOCKING} at or above ${FAIL_SEVERITY}"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### OpenAPI lint: \`${SPEC_PATH}\`"
+    echo ""
+    echo "| Severity | Findings | Blocking |"
+    echo "| --- | --- | --- |"
+    echo "| Error | ${ERRORS} | $(blocking 0) |"
+    echo "| Warning | ${WARNINGS} | $(blocking 1) |"
+    echo "| Info | ${INFOS} | $(blocking 2) |"
+    if [ "$INFOS" -gt 0 ]; then
+      echo ""
+      echo "<details><summary>Info findings by rule</summary>"
+      echo ""
+      echo "| Rule | Findings |"
+      echo "| --- | --- |"
+      jq -r '
+        [.[] | select(.severity == 2)]
+        | group_by(.code)
+        | map({code: .[0].code, n: length})
+        | sort_by(-.n)[]
+        | "| \(.code) | \(.n) |"
+      ' "$OUT"
+      echo ""
+      echo "</details>"
+    fi
+    echo ""
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Report-only downgrades the gate message only. Finding annotations keep their severity.
+GATE_LEVEL="error"
+if [ "$FAIL_ON_VIOLATION" != "true" ]; then
+  GATE_LEVEL="warning"
+fi
+
+if [ "$BLOCKING" -eq 0 ]; then
+  exit 0
+fi
+
+echo "::${GATE_LEVEL} file=${SPEC_PATH}::${BLOCKING} finding(s) at or above severity ${FAIL_SEVERITY}"
+
+if [ "$FAIL_ON_VIOLATION" = "true" ]; then
+  exit 1
+fi
+
+echo "Findings at or above ${FAIL_SEVERITY}, not failing the job because fail_on_violation is false"
+exit 0

--- a/.github/workflows/openapi_quality.yml
+++ b/.github/workflows/openapi_quality.yml
@@ -1,6 +1,6 @@
 name: OpenAPI Quality Check
 
-# this action runs only when OpenAPI spec files are modified
+# runs when the specs, the ruleset or the check itself change
 on:
   pull_request:
     branches:
@@ -8,6 +8,9 @@ on:
     paths:
       - 'api-spec/**/*.yaml'
       - 'api-spec/**/*.yml'
+      - '.spectral.yaml'
+      - '.github/actions/openapi-lint/**'
+      - '.github/workflows/openapi_quality.yml'
 
 permissions:
   contents: read
@@ -15,20 +18,21 @@ permissions:
 jobs:
   openapi_quality:
     runs-on: ubuntu-latest
-    name: OpenAPI Quality Check
+    name: OpenAPI lint
     strategy:
+      # one failing spec must not cancel the others
+      fail-fast: false
       matrix:
         spec:
           - path: 'api-spec/event-dispatcher-api.yaml'
+            version: 'v1'
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Rate My OpenAPI - ${{ matrix.spec.version }}
-        uses: zuplo/rmoa-action@c4a74a8823496c6061cd6fb586d80db8c2fd7e34  # v1
+      # blocks on errors; warnings stay visible until the spec is clean
+      - name: OpenAPI lint - ${{ matrix.spec.version }}
+        uses: ./.github/actions/openapi-lint
         with:
-          filepath: ${{ matrix.spec.path }}
-          apikey: ${{ secrets.RATEMYOPENAPI_API_KEY }}
-          minimum-score: 80
-          max-warnings: 12
-          max-errors: 5
+          spec_path: ${{ matrix.spec.path }}
+          fail_severity: error

--- a/.github/workflows/openapi_quality.yml
+++ b/.github/workflows/openapi_quality.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   openapi_quality:
     runs-on: ubuntu-latest
-    name: OpenAPI lint
+    name: OpenAPI lint ${{ matrix.spec.version }}
     strategy:
       # one failing spec must not cancel the others
       fail-fast: false
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # blocks on errors; warnings stay visible until the spec is clean
-      - name: OpenAPI lint - ${{ matrix.spec.version }}
+      - name: Lint ${{ matrix.spec.path }}
         uses: ./.github/actions/openapi-lint
         with:
           spec_path: ${{ matrix.spec.path }}

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,32 @@
+# OpenAPI ruleset, replaces Rate My OpenAPI
+# Rationale in the RFC "Linter OpenAPI: dismissione di Rate My OpenAPI".
+# Severity is the gate: a rule that should not block a PR is downgraded here by name
+# and with its reason, rather than absorbed by a numeric threshold. Errors and warnings
+# block by default (fail_severity), info is reported but never does.
+extends:
+  - [spectral:oas, recommended]          # base OpenAPI rules
+  - "@stoplight/spectral-owasp-ruleset"  # OWASP rules, not bundled with Spectral
+
+rules:
+  # Rate limiting is enforced by APIM, not declared per operation
+  owasp:api4:2023-rate-limit: off
+  owasp:api4:2023-rate-limit-retry-after: off
+  owasp:api4:2023-rate-limit-responses-429: off
+
+  # Unrestricted resource consumption: 390 findings, mostly on shared standard
+  # schemas such as ProblemJson (RFC 7807), where adding maxLength would be both
+  # wrong and laborious. Info keeps them visible and fixable without blocking.
+  owasp:api4:2023-string-limit: info
+  owasp:api4:2023-string-restricted: info
+  owasp:api4:2023-array-limit: info
+  owasp:api4:2023-integer-format: info
+  owasp:api4:2023-integer-limit: info
+  owasp:api4:2023-integer-limit-legacy: info
+
+  # An unreferenced schema can still back a generated DTO the service uses:
+  # e.g. DetailType backs DetailTypeDto in ResponseBuilderV1, deleting it breaks the build.
+  oas3-unused-component: info
+
+  # Internal API (*.internal.platform.pagopa.it), never called from a browser.
+  # CORS headers are handled by APIM.
+  owasp:api8:2023-define-cors-origin: off

--- a/api-spec/event-dispatcher-api.yaml
+++ b/api-spec/event-dispatcher-api.yaml
@@ -20,6 +20,7 @@ externalDocs:
   description: Design review
 servers:
   - url: https://${host}
+    x-internal: true
     variables:
       host:
           description: The hostname of the API server


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- replace the `zuplo/rmoa-action` step with a local `openapi-lint` composite action
- add `.spectral.yaml`, the ruleset calibrated on the pilot: OpenAPI recommended plus OWASP, with four rule decisions documented inline
- add `.github/actions/openapi-lint/`: action, gate script and README
- gate on `fail_severity: error` instead of `minimum-score` / `max-warnings` / `max-errors`
- add `x-internal: true` to `servers[0]`, clearing the only error-severity finding
- rename the job to `OpenAPI lint`, drop the `RATEMYOPENAPI_API_KEY` reference, widen the trigger to the ruleset and the action, add `fail-fast: false`
- add the missing `version` key to the matrix entry, which left the job name suffix empty

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

PIDM-2332, part of the dismissal of Rate My OpenAPI ([PIDM-2308](https://pagopa.atlassian.net/browse/PIDM-2308)). RMOA's API key expires periodically and blocks the pipelines of every repository using it, and it tunes only numeric thresholds rather than individual rules: rate limiting warnings that do not apply to us pushed `max-warnings` from 12 to 100 across the 13 repositories. Spectral runs locally with no API key, and a noisy rule is disabled or downgraded by name in a ruleset versioned with the code.

The action and the ruleset are copied per repository for now, to validate the check on real pull requests. They will shortly be ported to `pagopa/github-actions-template`, after which each repository drops its local copy and pins the shared action by SHA.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- gate script run locally against `api-spec/event-dispatcher-api.yaml`, Spectral 6.16.3 and OWASP ruleset 2.0.1 pinned: 0 errors, 1 warning, 13 info, exit 0
- canary spec with 9 deliberate OWASP violations: 9 errors, exit 1, so the gate does block
- unrecognised and unparseable documents: exit 1 in both, report-only included
- `OpenAPI lint` green on this pull request

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

[PIDM-2308]: https://pagopa.atlassian.net/browse/PIDM-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ